### PR TITLE
Add a delay to searching pages

### DIFF
--- a/apps/website/.vitepress/config.mts
+++ b/apps/website/.vitepress/config.mts
@@ -26,7 +26,7 @@ const docHead = [
 export default withPwa(defineConfig({
   title: "GSR",
   description: "Complete set of tools to scrape google search results",
-  cleanUrls: true,
+  cleanUrls: false,
   lastUpdated : true,
   head: docHead,
   sitemap: {

--- a/packages/google-sr/src/helpers.ts
+++ b/packages/google-sr/src/helpers.ts
@@ -82,3 +82,7 @@ export function pageToGoogleQueryPage(page: number) {
 
 export const generateArrayOfNumbers = (maxNumber: number) =>
   new Array(maxNumber).fill(0).map((_, index) => index + 1);
+
+
+
+export const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))

--- a/packages/google-sr/src/loaders.ts
+++ b/packages/google-sr/src/loaders.ts
@@ -2,7 +2,6 @@ import type { CheerioAPI } from "cheerio";
 
 // only types
 import type {
-
   // nodes
   SearchResultNode,
   TranslateResultNode,

--- a/packages/google-sr/src/search.ts
+++ b/packages/google-sr/src/search.ts
@@ -10,6 +10,7 @@ import {
   constructSearchConfig,
   generateArrayOfNumbers,
   pageToGoogleQueryPage,
+  sleep,
 } from "./helpers";
 import { deepmerge } from "deepmerge-ts";
 import {
@@ -91,9 +92,9 @@ export async function search(searchOptions: Partial<SearchOptions>) {
 
 /**
  * Search multiple pages
- * @param query
- * @param pages no of pages or array of pages numbers to retrieve
  * @param options
+ * @param options.pages no of pages / array of pages numbers to retrieve
+ * @param options.searchDelay amount of milliseconds (ms) the package should wait between retrieving results (default is disabled) useful with ratelimits
  * @returns Array of arrays representing pages containing search results
  *
  * @example
@@ -119,8 +120,9 @@ export async function search(searchOptions: Partial<SearchOptions>) {
  */
 export async function searchWithPages({
   pages,
+  searchDelay = 0,
   ...options
-}: Partial<Omit<SearchOptions, "page">> & { pages: number | number[] }) {
+}: Partial<Omit<SearchOptions, "page">> & { pages: number | number[]; searchDelay?: number }) {
   const queryPages = Array.isArray(pages)
     ? pages
     : generateArrayOfNumbers(pages);
@@ -130,6 +132,8 @@ export async function searchWithPages({
     (options as SearchOptions).page = pageToGoogleQueryPage(page);
     const result = await search(options);
     pagesResults.push(result);
+    // if search delay is enabled 
+    searchDelay && await sleep(searchDelay);
   }
 
   return pagesResults;

--- a/packages/google-sr/tests/multi.ts
+++ b/packages/google-sr/tests/multi.ts
@@ -10,4 +10,17 @@ describe("#searchWithPages", () => {
             expect(entry).length.to.be.greaterThan(1)
         });
     });
+
+    it("Search with delay", async function () {
+        const start = Date.now()
+        this.timeout(10000)
+        const queryWithPages = await searchWithPages({ query: 'npm js', pages: 3, searchDelay: 1000 });
+        const end = Date.now()
+        // just a simple check to make sure took more than 3 s (3 pages, 1s per page)
+        expect(end-start).greaterThan(3000)
+        expect(queryWithPages).to.have.lengthOf(3)
+        queryWithPages.every((entry) => {
+            expect(entry).length.to.be.greaterThan(1)
+        });
+    });
 })


### PR DESCRIPTION
This pull request adds the feature / option & tests for the `searchDelay` option in `searchWithPage`, it should help us avoid rate-limits by delaying requests