### PR TITLE
chore: Update workflows

### DIFF
--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -1,4 +1,4 @@
-name: Lint PR
+name: CI
 on:
   pull_request:
     types: [opened, reopened, edited, synchronize]

--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -14,14 +14,15 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v2
+        uses: pnpm/action-setup@v4
         with:
-          version: 9
+          version: 9.6.0
+          run_install: false
 
-      - name: Setting up node v18.x
-        uses: actions/setup-node@v3
+      - name: Install Node.js 20.x
+        uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
           cache: "pnpm"
 
       - name: Install workspace dependencies

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,4 +1,4 @@
-name: Test core selectors
+name: Test packages
 
 on:
   push:
@@ -12,27 +12,28 @@ on:
 
 jobs:
   test:
-    name: Test scraping selectors
+    name: Test packages
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@v3
 
+      # setup pnpm to specific version to avoid breaking changes
       - name: Setup pnpm
-        uses: pnpm/action-setup@v2
+        uses: pnpm/action-setup@v4
         with:
-          version: 8
+          version: 9.6.0
+          run_install: false
 
-      - name: Setting up node v18.x
-        uses: actions/setup-node@v3
+      # action was tested on node 20.x
+      - name: Install Node.js 20.x
+        uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
           cache: 'pnpm'
 
       - name: Install dependencies
-        run: pnpm install --no-frozen-lockfile
+        run: pnpm install --frozen-lockfile
 
       - name: Build Package using tsup and turbo
         run: pnpm run build --filter=google-sr --filter=google-sr-selectors

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,4 +1,4 @@
-name: Test packages
+name: Test
 
 on:
   push:
@@ -12,7 +12,7 @@ on:
 
 jobs:
   test:
-    name: Test packages
+    name: Main package
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "node": ">=15.0.0",
     "pnpm": ">=7"
   },
-  "packageManager": "pnpm@8.6.12",
+  "packageManager": "pnpm@9.6.0",
   "devDependencies": {
     "@biomejs/biome": "1.8.3",
     "@commitlint/cli": "19.3.0",


### PR DESCRIPTION
Current workflows contains outdated action versions.

Refer below:

pnpm/action-setup@v2 -> pnpm/action-setup@v4 (https://github.com/pnpm/action-setup/issues/135)
actions/setup-node@v3 -> actions/setup-node@v4 (now using node 20x)

Some names of the workflows were renamed to better reflect on what they do.