### PR TITLE
chore: move docs to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,8 +108,12 @@ You can find it [here](https://codeberg.org/typicalninja/google-sr)
 # Disclaimer
 
 This is not sponsored, supported, or affiliated with Google Inc.
+
+Unlike the conventional recommendation of using the Google API, this module scrapes the Google search result page (which might potentially infringe upon Google's terms of service).
+
 The source code within this repository is intended solely for educational & research purposes.
-The author (typicalninja) & contributors takes **no** responsibility for any issues that arise from misuse, such as IP blocking by Google. Your discretion in usage is advised.
+
+The author (typicalninja) & contributors takes **NO** responsibility for any issues that arise from misuse, such as IP blocking by Google. Your discretion in usage is advised.
 
 # License
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ console.log(queryResult[0][0].type === ResultTypes.OrganicResult)
 
 > By default only `ResultTypes.OrganicResult` result type are returned, use the [resultTypes](#searchoptionsr--resultselector) option to configure it
 
-* Additional examples can be found in [tests](#tests) and [apps/examples](https://github.com/typicalninja/google-sr/tree/main/apps/examples) directory
+* Additional examples can be found in [tests](#tests) and [apps/examples](https://github.com/typicalninja/google-sr/tree/master/apps/examples) directory
 
 # google-sr API
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# google-sr 🔍
+# google-sr
 [![testing workflow](https://github.com/typicalninja/google-sr/actions/workflows/tests.yml/badge.svg)](https://github.com/typicalninja/google-sr)
 [![GitHub issues](https://img.shields.io/github/issues/typicalninja/google-sr)](https://github.com/typicalninja/google-sr/issues)
 [![GitHub Repo stars](https://img.shields.io/github/stars/typicalninja/google-sr)](https://github.com/typicalninja/google-sr/stargazers)
@@ -8,55 +8,69 @@
 
 Easy to use, updated tools for scraping google search results. 🚀
 
-* Documentation can be found [here](https://g-sr.vercel.app)
-
-* API documentation can be found [here](https://typicalninja.github.io/google-sr/index.html)
-
-## Install 📦
+# Install
 
 To get started, you can install **google-sr** using your preferred package manager:
 
 ```bash
-
 # npm
-
 npm install google-sr
 
 # pnpm 
-
 pnpm add google-sr
 
 # yarn
-
 yarn add google-sr
-
 ```
 
-## Usage
+# Usage
 
 You can easily perform a single-page search like this:
 
 ```ts
-import { search, ResultTypes } from 'google-sr';
+import { search, OrganicResult } from 'google-sr';
 
 // using await/async
-const searchResults = await search({ 
-    query: 'nodejs', 
-    safeMode: false, 
-    filterResults: [ResultTypes.SearchResult] 
+const queryResult = await search({
+    query: "nodejs",
+    // OrganicResult is the default, however it is recommended to always specify the result type
+    resultTypes: [OrganicResult],
 });
 
-// will return a []
-console.log(searchResults);
+// will return a SearchResult[]
+console.log(queryResult);
 // should log: true
-console.log(searchResults[0].type === ResultTypes.SearchResult)
+console.log(queryResult[0].type === ResultTypes.OrganicResult)
 ```
 
-* **Read about the returned types [here](https://g-sr.vercel.app/google/sr/types)**
+To search for multiple pages of results, use the `searchWithPages` function:
 
-* **More detailed examples & usage can be found [here](https://g-sr.vercel.app/google/sr/usage)**
+```ts
+import { searchWithPages, OrganicResult } from 'google-sr';
 
-## Monorepo
+// using await/async
+const queryResult = await searchWithPages({
+    query: "nodejs",
+    // OrganicResult is the default, however it is recommended to always specify the result type
+    resultTypes: [OrganicResult],
+    pages: 2,
+});
+
+// will return a SearchResult[][]
+console.log(queryResult);
+// should log: true
+console.log(queryResult[0][0].type === ResultTypes.OrganicResult)
+```
+
+> By default only `ResultTypes.OrganicResult` result type are returned, use the [resultTypes](#searchoptionsr--resultselector) option to configure it
+
+* Additional examples can be found in [tests](#tests) and [apps/examples](https://github.com/typicalninja/google-sr/tree/main/apps/examples) directory
+
+# google-sr API
+
+Please refer to the google-sr readme in [packages/google-sr](https://github.com/typicalninja/google-sr/blob/master/packages/google-sr/README.md)
+
+# Monorepo
 
 Welcome to the 📦 monorepo of GSR Project.
  
@@ -84,37 +98,19 @@ Welcome to the 📦 monorepo of GSR Project.
 
 This monorepo is managed with [turborepo](https://turbo.build/repo) and uses [pnpm workspaces](https://pnpm.io/workspaces).
 
-## Mirror 🪞
+# Mirror
 
 GSR project has a mirror repository on codeberg 
 You can find it [here](https://codeberg.org/typicalninja/google-sr)
 
 * All issues and discussion are limited to github & discord
 
-## Disclaimer
+# Disclaimer
 
 This is not sponsored, supported, or affiliated with Google Inc.
-The source code within this repository is intended solely for educational purposes.
-
+The source code within this repository is intended solely for educational & research purposes.
 The author (typicalninja) & contributors takes **no** responsibility for any issues that arise from misuse, such as IP blocking by Google. Your discretion in usage is advised.
 
-## Tests
-
-Tests are written using [mocha](https://mochajs.org/) and can be run by using the `test` script.
-
-> Weekly tests are executed using a github action to ensure compatibility
-
-This monorepo uses pnpm as its package manager
-
-```bash
-pnpm run test
-```
-
-## Support & Bug Reporting 🛠️🐞
-
-> Make sure you are on the latest version before creating bug reports
-
-Support and bug reporting both can be done on  [github issues](https://github.com/typicalninja/google-sr/issues)
-## License
+# License
 
 This repository and the code inside it is licensed under the Apache-2.0 License. Read [LICENSE](./LICENSE) for more information.

--- a/packages/google-sr-selectors/README.md
+++ b/packages/google-sr-selectors/README.md
@@ -11,47 +11,33 @@
 
 Set of html selectors for parsing google search results with jquery like modules (ex: cheerio).
 
-
-* View documentation [here](https://g-sr.vercel.app/google/selectors)
-
-* Come chat with us on [our discord](https://discord.gg/ynwckXS9T2)
-
-
 Please note that the included selectors are intended for the **non-Javascript** version of Google Search page. 
 These were obtained by appending `&gbv=1` to the regular query link.
 
 ex: (disable javascript, else it will redirect): [query `nodejs`](https://www.google.com/search?hl=en&q=nodejs&gbv=1)
 
-## What are selectors?
+# Supported types
 
-Selectors form the backbone of packages like google-sr. These are predefined strings that outline the structure of specific HTML code representing the desired value. 
-By utilizing selectors, we gain the ability to parse the HTML and precisely extract the intended information.
-
-This package exports the selectors used to extract search result values from, google html page data we receive.
-Offered for purposes of contributors and other developers interested in parsing raw google search html.
-
-## Supported types
-
-The package currently only supports a limited amount of selectors
-
-You can view them in the [documentation](https://g-sr.vercel.app/google/selectors)
+The package currently only supports a limited amount search result types
 
 🌟 Suggest more to be added [here](https://github.com/typicalninja/google-sr/discussions/new?category=ideas)
 
-## Related projects 🥂
+# Related projects 🥂
 
 * [google-sr](https://g-sr.vercel.app/google/sr) - Simple tool to programmatically get google search results
 * [google-that](https://g-sr.vercel.app/google/that) - CLI wrapper around google-sr
 
 
-## Disclaimer
+# Disclaimer
 
 This is not sponsored, supported, or affiliated with Google Inc.
 
-The source code within this repository is intended solely for educational purposes.
+Unlike the conventional recommendation of using the Google API, this module scrapes the Google search result page (which might potentially infringe upon Google's terms of service).
 
-The author (typicalninja) & contributors takes **no** responsibility for any issues that arise from misuse, such as IP blocking by Google. Your discretion in usage is advised.
+The source code within this repository is intended solely for educational & research purposes.
 
-## License
+The author (typicalninja) & contributors takes **NO** responsibility for any issues that arise from misuse, such as IP blocking by Google. Your discretion in usage is advised.
+
+# License
 
 This repository and the code inside it is licensed under the Apache-2.0 License. Read [LICENSE](./LICENSE) for more information.

--- a/packages/google-sr/README.md
+++ b/packages/google-sr/README.md
@@ -8,104 +8,237 @@
 [![Discord](https://img.shields.io/discord/807868280387665970)](https://discord.gg/ynwckXS9T2)
 [![CodeFactor](https://www.codefactor.io/repository/github/typicalninja/google-sr/badge)](https://www.codefactor.io/repository/github/typicalninja/google-sr)
 
-
 Simple & Fast Package for scraping Google search results without the need for an API key. 🚀
 
-* View documentation [here](https://g-sr.vercel.app)
+# Table of Contents
 
-* Come chat with us on [our discord](https://discord.gg/ynwckXS9T2)
+* [Features](#features)
+* [Install](#install)
+* [Usage](#usage)
+* [google-sr API](#google-sr-api)
+  * [search(SearchOptions\<R>)](#searchsearchoptionsr-promisesearchresulttyper)
+    * [SearchOptions\<R>](#searchoptionsr--resultselector)
+  * [searchWithPages(SearchOptionsWithPages\<R>)](#searchwithpagessearchoptionswithpagesr-promisesearchresulttyper)
+    * [SearchOptionsWithPages\<R>](#searchoptionswithpagesr--resultselector)
+  * [ResultSelector](#resultselector)
+  * [SearchResultNode](#searchresultnode)
+    * [OrganicResult](#organicresult)
+    * [TranslateResult](#translateresult)
+    * [DictionaryResult](#dictionaryresult)
+    * [TimeResult](#timeresult)
+    * [CurrencyResult](#currencyresult)
+  * [ResultTypes](#resulttypes)
+* [Disclaimer](#disclaimer)
+* [Related projects 🥂](#related-projects)
+* [Tests](#tests)
+* [Support & Bug Reporting 🛠️🐞](#support--bug-reporting)
+* [License](#license)
 
-## Features ✨
+# Features
 
-* Simple & Fast ⚡️ *
+* Simple to use
 * [Well tested 🔄](#tests)
-* [Well documented 📚](https://g-sr.vercel.app)
-* TypeScript compatible 🧑‍💻
+* Available for both typescript and javascript
 * No API key is needed 🔑
-* [Wide variety of search result types supported 🌴](https://g-sr.vercel.app/google/sr/types)
 
-## Install 📦
+# Install 📦
 
 To get started, you can install **google-sr** using your preferred package manager:
 
+> google-sr is not supported on browser environments.
+
 ```bash
-
-# npm
-
 npm install google-sr
-
-# pnpm 
-
-pnpm add google-sr
-
-# yarn
-
-yarn add google-sr
-
+# or pnpm / yarn add google-sr
 ```
 
-## Usage
+# Usage
 
 You can easily perform a single-page search like this:
 
 ```ts
-import { search, ResultTypes } from 'google-sr';
+import { search, OrganicResult } from 'google-sr';
 
 // using await/async
-const searchResults = await search({ 
-    query: 'nodejs', 
-    safeMode: false, 
-    filterResults: [ResultTypes.SearchResult] 
+const queryResult = await search({
+    query: "nodejs",
+    // OrganicResult is the default, however it is recommended to always specify the result type
+    resultTypes: [OrganicResult],
 });
 
-// will return a []
+// will return a SearchResult[]
 console.log(searchResults);
 // should log: true
-console.log(searchResults[0].type === ResultTypes.SearchResult)
+console.log(searchResults[0].type === ResultTypes.OrganicResult)
 ```
 
-* **Read about the returned types [here](https://g-sr.vercel.app/google/sr/types)**
+To search for multiple pages of results, use the `searchWithPages` function:
 
-* **More detailed examples & usage can be found [here](https://g-sr.vercel.app/google/sr/usage)**
+```ts
+import { searchWithPages, OrganicResult } from 'google-sr';
 
-> By default only [`ResultTypes.SearchResult`](https://g-sr.vercel.app/google/sr/types#regular-search-results) are returned, use the [filterResults](https://g-sr.vercel.app/google/sr/usage#filtering-search-results) option to configure it
+// using await/async
+const queryResult = await searchWithPages({
+    query: "nodejs",
+    // OrganicResult is the default, however it is recommended to always specify the result type
+    resultTypes: [OrganicResult],
+    pages: 2,
+});
 
-* Additional examples can be found in [tests](#tests) and apps directory
+// will return a SearchResult[][]
+console.log(searchResults);
+// should log: true
+console.log(searchResults[0][0].type === ResultTypes.OrganicResult)
+```
+
+> By default only `ResultTypes.OrganicResult` result type are returned, use the [resultTypes](#searchoptionsr--resultselector) option to configure it
+
+* Additional examples can be found in [tests](#tests) and [apps/examples](https://github.com/typicalninja/google-sr/tree/main/apps/examples) directory
+
+# google-sr API
+
+## search([SearchOptions\<R>](#searchoptionsr--resultselector)): Promise\<SearchResultType\<R>[]\>
+
+Query a single page of google results.
+
+## searchWithPages([SearchOptionsWithPages\<R>](#searchoptionswithpagesr--resultselector)): Promise\<SearchResultType\<R>[][]\>
+
+Query multiple pages of google results. google uses cursor-based pagination (using param start=number), therefore, when providing the pages to query, make sure to provide a single page number (for auto pagination) or provide an array of page numbers of 10 increments, starting at 10 (for manual pagination).
+
+## SearchOptions\<R = [ResultSelector](#resultselector)>
+
+* **query**: `string` - The query to search for
+* **safeMode**: `boolean` - Toggle to enable google safe mode
+* **resultTypes**: `R[]` - Control the type of results returned (can have a significant performance impact)
+* **strictSelector**: `boolean` - when true, will only return resultNodes that do not contain any undefined/empty 
+properties
+* **requestConfig**: [`AxiosRequestConfig`](https://axios-http.com/docs/req_config) - Custom request configuration to be sent with the request.
+
+## SearchOptionsWithPages\<R = ResultSelector> extends [SearchOptions\<R>](#searchoptionsr--resultselector)
+
+* **pages**: `number | number[]` - Total number of pages to search or an array of specific pages to search
+
+## ResultSelector
+
+A function that accepts a cheerio instance and returns an array of SearchResultNodes.
+
+`(cheerio: CheerioAPI, strictSelector: boolean) => SearchResultNode[]`
+
+## SearchResultNode
+
+An interface that represents a single search result node. Each node has a type property that identifies the type of result.
+
+```ts
+interface SearchResultNode {
+  type: ResultTypes;
+}
+```
 
 
-## Disclaimer
+#### OrganicResult
+
+```ts
+interface OrganicResultNode extends SearchResultNode {
+  type: ResultTypes.OrganicResult;
+  link: string;
+  description: string;
+  title: string;
+}
+```
+
+#### TranslateResult
+
+```ts
+interface TranslateResultNode extends SearchResultNode {
+  type: ResultTypes.TranslateResult;
+  sourceLanguage: string;
+  sourceText: string;
+  translationLanguage: string;
+  translationText: string;
+  translationPronunciation: string;
+}
+```
+
+#### DictionaryResult
+
+```ts
+interface DictionaryResultNode extends SearchResultNode {
+  type: ResultTypes.DictionaryResult;
+  audio: string;
+  phonetic: string;
+  word: string;
+  definitions: [string, string][];
+}
+```
+
+#### TimeResult
+
+```ts
+interface TimeResultNode extends SearchResultNode {
+  type: ResultTypes.TimeResult;
+  location: string;
+  time: string;
+  timeInWords: string;
+}
+```
+
+#### CurrencyResult
+
+```ts
+interface CurrencyResultNode extends SearchResultNode {
+  type: ResultTypes.CurrencyResult;
+  from: string;
+  to: string;
+}
+```
+
+## ResultTypes
+
+An enum that represents the different types of search results.
+
+```ts
+enum ResultTypes {
+  OrganicResult = "ORGANIC",
+  TranslateResult = "TRANSLATE",
+  DictionaryResult = "DICTIONARY",
+  TimeResult = "TIME",
+  CurrencyResult = "CURRENCY",
+}
+```
+
+# ⚠️ Disclaimer
 
 This is not sponsored, supported, or affiliated with Google Inc.
 
 Unlike the conventional recommendation of using the Google API, this module scrapes the Google search result page (which might potentially infringe upon Google's terms of service).
 
-The source code within this repository is intended solely for educational purposes.
+The source code within this repository is intended solely for educational & research purposes.
 
-The author (typicalninja) & contributors takes **no** responsibility for any issues that arise from misuse, such as IP blocking by Google. Your discretion in usage is advised.
+The author (typicalninja) & contributors takes **NO** responsibility for any issues that arise from misuse, such as IP blocking by Google. Your discretion in usage is advised.
 
-## Related projects 🥂
+# Related projects 🥂
 
 * [google-that](https://g-sr.vercel.app/google/that) - CLI wrapper around google-sr
 * [google-sr-selectors](https://g-sr.vercel.app/google/selectors) - Selectors for google search results used by google-sr
 
 # Tests
 
-Tests are written using [mocha](https://mochajs.org/) and can be run by using the `test` script.
+Tests are written using [vitest](https://vitest.dev/) and can be run by using the `test` script.
 
-> Weekly tests a executed using a github action to ensure compatibility
+> Weekly tests are executed using a github action to ensure compatibility and catch breakage due google changes
 
-Project uses pnpm as its package manager
+google-sr uses pnpm as its package manager
 
 ```bash
 pnpm run test
 ```
 
-## Support & Bug Reporting 🛠️🐞
+# Support & Bug Reporting 🛠️🐞
 
 > Make sure you are on the latest version before creating bug reports
 
 Support and bug reporting both can be done on  [github issues](https://github.com/typicalninja/google-sr/issues)
 
-## License
+# License
 
 This repository and the code inside it is licensed under the Apache-2.0 License. Read [LICENSE](./LICENSE) for more information.

--- a/packages/google-sr/README.md
+++ b/packages/google-sr/README.md
@@ -67,9 +67,9 @@ const queryResult = await search({
 });
 
 // will return a SearchResult[]
-console.log(searchResults);
+console.log(queryResult);
 // should log: true
-console.log(searchResults[0].type === ResultTypes.OrganicResult)
+console.log(queryResult[0].type === ResultTypes.OrganicResult)
 ```
 
 To search for multiple pages of results, use the `searchWithPages` function:
@@ -86,9 +86,9 @@ const queryResult = await searchWithPages({
 });
 
 // will return a SearchResult[][]
-console.log(searchResults);
+console.log(queryResult);
 // should log: true
-console.log(searchResults[0][0].type === ResultTypes.OrganicResult)
+console.log(queryResult[0][0].type === ResultTypes.OrganicResult)
 ```
 
 > By default only `ResultTypes.OrganicResult` result type are returned, use the [resultTypes](#searchoptionsr--resultselector) option to configure it

--- a/packages/google-sr/README.md
+++ b/packages/google-sr/README.md
@@ -19,7 +19,7 @@ Simple & Fast Package for scraping Google search results without the need for an
   * [search(SearchOptions\<R>)](#searchsearchoptionsr-promisesearchresulttyper)
     * [SearchOptions\<R>](#searchoptionsr--resultselector)
   * [searchWithPages(SearchOptionsWithPages\<R>)](#searchwithpagessearchoptionswithpagesr-promisesearchresulttyper)
-    * [SearchOptionsWithPages\<R>](#searchoptionswithpagesr--resultselector)
+    * [SearchOptionsWithPages\<R>](#searchoptionswithpagesr--resultselector-extends-searchoptionsr)
   * [ResultSelector](#resultselector)
   * [SearchResultNode](#searchresultnode)
     * [OrganicResult](#organicresult)
@@ -28,10 +28,10 @@ Simple & Fast Package for scraping Google search results without the need for an
     * [TimeResult](#timeresult)
     * [CurrencyResult](#currencyresult)
   * [ResultTypes](#resulttypes)
-* [Disclaimer](#disclaimer)
-* [Related projects 🥂](#related-projects)
+* [Disclaimer](#️-disclaimer)
+* [Related projects 🥂](#related-projects-)
 * [Tests](#tests)
-* [Support & Bug Reporting 🛠️🐞](#support--bug-reporting)
+* [Support & Bug Reporting 🛠️🐞](#support--bug-reporting-️)
 * [License](#license)
 
 # Features

--- a/packages/google-sr/README.md
+++ b/packages/google-sr/README.md
@@ -93,7 +93,7 @@ console.log(queryResult[0][0].type === ResultTypes.OrganicResult)
 
 > By default only `ResultTypes.OrganicResult` result type are returned, use the [resultTypes](#searchoptionsr--resultselector) option to configure it
 
-* Additional examples can be found in [tests](#tests) and [apps/examples](https://github.com/typicalninja/google-sr/tree/main/apps/examples) directory
+* Additional examples can be found in [tests](#tests) and [apps/examples](https://github.com/typicalninja/google-sr/tree/master/apps/examples) directory
 
 # google-sr API
 

--- a/packages/google-that/README.md
+++ b/packages/google-that/README.md
@@ -9,9 +9,6 @@
 
 CLI tool to scrape google search results without an api key 🚀.
 
-* View documentation [here](https://g-sr.vercel.app/google/selectors)
-
-* Come chat with us on [our discord](https://discord.gg/ynwckXS9T2)
 
 ## Install 📦
 
@@ -22,17 +19,13 @@ To get started, you can install **google-that** using your preferred package man
 ```bash
 
 # npm
-
 npm install -g google-that
 
 # pnpm 
-
 pnpm add -g google-that
 
 # yarn
-
 yarn add -g google-that
-
 ```
 
 ## Usage
@@ -48,21 +41,21 @@ google-that
 This will start the google-that process.
 
 
-## Related projects 🥂
+# Related projects 🥂
 
 * [google-sr](https://g-sr.vercel.app/google/sr) - Core project used in google-that
 * [google-sr-selectors](https://g-sr.vercel.app/google/selectors) - Selectors for google search results used by google-sr
 
-## Disclaimer
+# Disclaimer
 
 This is not sponsored, supported, or affiliated with Google Inc.
 
 Unlike the conventional recommendation of using the Google API, this module scrapes the Google search result page (which might potentially infringe upon Google's terms of service).
 
-The source code within this repository is intended solely for educational purposes.
+The source code within this repository is intended solely for educational & research purposes.
 
-The author (typicalninja) & contributors takes **no** responsibility for any issues that arise from misuse, such as IP blocking by Google. Your discretion in usage is advised.
+The author (typicalninja) & contributors takes **NO** responsibility for any issues that arise from misuse, such as IP blocking by Google. Your discretion in usage is advised.
 
-## License
+# License
 
 This repository and the code inside it is licensed under the Apache-2.0 License. Read [LICENSE](./LICENSE) for more information.


### PR DESCRIPTION
We are removing the vercel/vitepress docs in favor of github pages and readme docs