### PR TITLE
chore: fix some required exports missing

### DIFF
--- a/packages/google-sr/src/index.ts
+++ b/packages/google-sr/src/index.ts
@@ -1,3 +1,8 @@
 export * from "./search";
 export * from "./results";
 export * from "./constants";
+
+export {
+	ResultNodeTyper,
+	SearchResultTypeFromSelector,
+} from "./utils";

--- a/packages/google-sr/src/utils.ts
+++ b/packages/google-sr/src/utils.ts
@@ -125,7 +125,7 @@ export type NonNullableRecord<T> = { [K in keyof T]: NonNullable<T[K]> };
 /**
  * Generic type for the search results, derives the resultTypes from selector array.
  */
-export type SearchResultType<
+export type SearchResultTypeFromSelector<
 	R extends ResultSelector,
 	S extends boolean = false,
 > = S extends true


### PR DESCRIPTION
The utility types `ResultNodeTyper` and `SearchResultTypeFromSelector` (renamed) were not exported. While they are internal types, they are required for advanced use cases.