### PR TITLE
fix(gsr): Patch dictionary selectors + fix gsr dictionary results

### DIFF
--- a/packages/google-sr-selectors/src/index.ts
+++ b/packages/google-sr-selectors/src/index.ts
@@ -17,9 +17,15 @@ export const DictionarySearchSelector = {
 	audio: "h3.zBAuLc.l97dzf > div.BNeawe > audio",
 	phonetic: "span > div.BNeawe.tAd8D.AP7Wnd",
 	word: "span.lU7jec > h3.zBAuLc.l97dzf > div.BNeawe",
-	examples: "div.v9i61e > div.BNeawe > span.r0bn4c.rQMQod",
-	definitions:
-		"div.v9i61e > div.BNeawe.s3v9rd.AP7Wnd:not(:has(span.r0bn4c.rQMQod))",
+	// there can be multiple definitions
+	// use definitionPartOfSpeech as reference to how many definitions there are
+	// there are no reliable way other than that to get definitions
+	definition: "div.v9i61e > div.BNeawe.s3v9rd.AP7Wnd:not(:has(span))",
+	definitionPartOfSpeech:
+		"div.Ap5OSd > div.BNeawe.s3v9rd.AP7Wnd > span.r0bn4c.rQMQod",
+	definitionExample: "div.v9i61e > div.BNeawe.s3v9rd.AP7Wnd:has(span)",
+	definitionSynonyms:
+		"div:not(.v9i61e):not(.Ap5OSd) > div.BNeawe.s3v9rd.AP7Wnd > span.r0bn4c.rQMQod",
 };
 
 export const TimeSearchSelector = {

--- a/packages/google-sr-selectors/src/index.ts
+++ b/packages/google-sr-selectors/src/index.ts
@@ -14,9 +14,9 @@ export const TranslateSearchSelector = {
 };
 
 export const DictionarySearchSelector = {
-	audio: "audio:first",
+	audio: "h3.zBAuLc.l97dzf > div.BNeawe > audio",
 	phonetic: "span > div.BNeawe.tAd8D.AP7Wnd",
-	word: "h3 > div.BNeawe.deIvCb.AP7Wnd",
+	word: "span > h3.zBAuLc.l97dzf > div.BNeawe",
 	examples: "div.v9i61e > div.BNeawe > span.r0bn4c.rQMQod",
 	definitions:
 		"div.v9i61e > div.BNeawe.s3v9rd.AP7Wnd:not(:has(span.r0bn4c.rQMQod))",

--- a/packages/google-sr-selectors/src/index.ts
+++ b/packages/google-sr-selectors/src/index.ts
@@ -16,7 +16,7 @@ export const TranslateSearchSelector = {
 export const DictionarySearchSelector = {
 	audio: "h3.zBAuLc.l97dzf > div.BNeawe > audio",
 	phonetic: "span > div.BNeawe.tAd8D.AP7Wnd",
-	word: "span > h3.zBAuLc.l97dzf > div.BNeawe",
+	word: "span.lU7jec > h3.zBAuLc.l97dzf > div.BNeawe",
 	examples: "div.v9i61e > div.BNeawe > span.r0bn4c.rQMQod",
 	definitions:
 		"div.v9i61e > div.BNeawe.s3v9rd.AP7Wnd:not(:has(span.r0bn4c.rQMQod))",

--- a/packages/google-sr-selectors/src/index.ts
+++ b/packages/google-sr-selectors/src/index.ts
@@ -14,6 +14,7 @@ export const TranslateSearchSelector = {
 };
 
 export const DictionarySearchSelector = {
+	// use attr('src') to get the audio url
 	audio: "h3.zBAuLc.l97dzf > div.BNeawe > audio",
 	phonetic: "span > div.BNeawe.tAd8D.AP7Wnd",
 	word: "span.lU7jec > h3.zBAuLc.l97dzf > div.BNeawe",

--- a/packages/google-sr/src/constants.ts
+++ b/packages/google-sr/src/constants.ts
@@ -23,11 +23,18 @@ export type TranslateResultNode = ResultNodeTyper<
 	| "translationText"
 	| "translationPronunciation"
 >;
+export interface DictionaryDefinition {
+	partOfSpeech: string;
+	definition: string;
+	example: string;
+	synonyms: string[];
+}
 // Dictionary result contains a special property called definitions which is an array
 export type DictionaryResultNode = ResultNodeTyper<
 	typeof ResultTypes.DictionaryResult,
 	"audio" | "phonetic" | "word"
-> & { definitions: [string, string][] };
+> & { definitions: DictionaryDefinition[] };
+
 export type TimeResultNode = ResultNodeTyper<
 	typeof ResultTypes.TimeResult,
 	"location" | "time" | "timeInWords"


### PR DESCRIPTION
google updated the page structure a while back, and I finally had time to fix it. This PR also adds full support for retrieving accurate definitions from dictionary results.

Previously, dictionary definitions were returned as a `[string, string][]`. Now, an object is returned with the following properties:

```ts
interface DictionaryDefinition {
	partOfSpeech: string; // verb, noun etc
	definition: string;
	example: string;
	synonyms: string[];
}
```

This new structure is much more complete than the previous version, which only included `partOfSpeech` and `definition`. ([string, string]).

Note: this is a breaking change