### PR TITLE
refactor(selectors): Patch organic search result

### DIFF
--- a/.changeset/tidy-ducks-end.md
+++ b/.changeset/tidy-ducks-end.md
@@ -1,0 +1,5 @@
+---
+"google-sr-selectors": patch
+---
+
+Patche organic search block selector

--- a/packages/google-sr-selectors/src/index.ts
+++ b/packages/google-sr-selectors/src/index.ts
@@ -1,5 +1,5 @@
 export const OrganicSearchSelector = {
-	block: ".Gx5Zad.fP1Qef.xpd.EtOod.pkphOe",
+	block: ".Gx5Zad.xpd.EtOod.pkphOe",
 	link: "[data-ved]",
 	title: "h3.zBAuLc",
 	description: ".BNeawe.s3v9rd.AP7Wnd",

--- a/packages/google-sr-selectors/src/index.ts
+++ b/packages/google-sr-selectors/src/index.ts
@@ -1,5 +1,5 @@
 export const OrganicSearchSelector = {
-	block: ".Gx5Zad.xpd.EtOod.pkphOe",
+	block: "div:not([data-hveid]):not(.yStFkb) > div.Gx5Zad.xpd.EtOod.pkphOe",
 	link: "[data-ved]",
 	title: "h3.zBAuLc",
 	description: ".BNeawe.s3v9rd.AP7Wnd",

--- a/packages/google-sr/tests/result.test.ts
+++ b/packages/google-sr/tests/result.test.ts
@@ -21,7 +21,6 @@ test("Search for organic results (default)", async () => {
 
 	// verify all results are OrganicResults
 	for (const result of queryResult) {
-		console.log(result);
 		expect(result.type).toBe(ResultTypes.OrganicResult);
 
 		// verify properties are present and not empty;

--- a/packages/google-sr/tests/result.test.ts
+++ b/packages/google-sr/tests/result.test.ts
@@ -21,6 +21,7 @@ test("Search for organic results (default)", async () => {
 
 	// verify all results are OrganicResults
 	for (const result of queryResult) {
+		console.log(result);
 		expect(result.type).toBe(ResultTypes.OrganicResult);
 
 		// verify properties are present and not empty;


### PR DESCRIPTION
New selector: `div:not([data-hveid]):not(.yStFkb) > div.Gx5Zad.xpd.EtOod.pkphOe`

`data-hveid` and `.yStFkb` filters our similar questions section.