### PR TITLE
test(gsr): Fix translate query test

### DIFF
--- a/packages/google-sr/tests/result.test.ts
+++ b/packages/google-sr/tests/result.test.ts
@@ -32,7 +32,7 @@ test("Search for organic results (default)", async () => {
 
 test("Search for translation results", async () => {
 	const queryResult = await search({
-		query: "translate hello to spanish",
+		query: "translate hello to japanese",
 		resultTypes: [TranslateResult],
 	});
 	// only one result should be returned for this query


### PR DESCRIPTION
Just a simple fix. old query did not return a result with `translationPronunciation` so tests were failing.