### PR TITLE
refactor: add support for custom selectors

### DIFF
--- a/.changeset/cyan-hotels-yawn.md
+++ b/.changeset/cyan-hotels-yawn.md
@@ -1,0 +1,21 @@
+---
+"google-sr": minor
+---
+
+Support custom selectors
+
+Use the new `ResultNodeTyper` to create a custom node, and use the `ResultSelector` to create a function that will parse the raw html for results and return a node.
+
+```ts
+import { ResultNodeTyper, ResultSelector } from "google-sr"
+// first argument is the "type" value (string) of the node, second is all the properties of the node
+type DidYouKnow = 
+ResultNodeTyper<"SOMETYPE", "prop1" | "prop2"> 
+// properties that are not string can be defined as this
+& { descriptions: string[] } 
+const selector: ResultSelector<DidYouKnow> = ($, strictSelector) => { 
+    // return node
+}
+
+search({ resultTypes: [selector] })
+```

--- a/.changeset/selfish-trains-exist.md
+++ b/.changeset/selfish-trains-exist.md
@@ -15,21 +15,5 @@ search({
 })
 ```
 
-Use the new `ResultNodeTyper` to create a custom node.
-
-```ts
-import { ResultNodeTyper, ResultSelector } from "google-sr"
-// first argument is the "type" value (string) of the node, second is all the properties of the node
-type DidYouKnow = 
-ResultNodeTyper<"SOMETYPE", "prop1" | "prop2"> 
-// properties that are not string can be defined as this
-& { descriptions: string[] } 
-const selector: ResultSelector<DidYouKnow> = ($, strictSelector) => { 
-    // return node
-}
-
-search({ resultTypes: [selector] })
-```
-
 Check the newly added api documentation [here](https://github.com/typicalninja/google-sr/tree/master/packages/google-sr#google-sr-api)
 

--- a/apps/examples/src/custom-selector.ts
+++ b/apps/examples/src/custom-selector.ts
@@ -4,18 +4,31 @@
  */
 
 import {
-	type OrganicResultNode,
+	// little helper to create a type for the result node (optional)
+	type ResultNodeTyper,
 	type ResultSelector,
-	ResultTypes,
 	search,
 } from "google-sr";
 
-const customSelector: ResultSelector<OrganicResultNode> = () => {
+type CustomResultNode = ResultNodeTyper<"CUSTOM", "title"> & {
+	examples: string[];
+};
+
+/*
+Or without the type helper:
+
+interface CustomResultNode {
+	type: 'CUSTOM'
+	title: string
+	examples: string[]
+}
+*/
+
+const customSelector: ResultSelector<CustomResultNode> = () => {
 	return {
-		type: ResultTypes.OrganicResult,
+		type: "CUSTOM",
 		title: "Some title",
-		link: "Some link",
-		description: "Some description",
+		examples: ["example1", "example2"],
 	};
 };
 
@@ -24,4 +37,4 @@ const results = await search({
 	resultTypes: [customSelector],
 });
 
-console.log(results);
+console.log(results[0]);

--- a/packages/google-sr/src/constants.ts
+++ b/packages/google-sr/src/constants.ts
@@ -51,11 +51,15 @@ export type SearchResultNode =
 	| DictionaryResultNode
 	| TimeResultNode
 	| CurrencyResultNode;
+
+export interface SearchResultNodeLike {
+	type: string;
+}
+
 // the type used to identify a parser/selector function
-export type ResultSelector<R extends SearchResultNode = SearchResultNode> = (
-	cheerio: CheerioAPI,
-	strictSelector: boolean,
-) => R[] | R | null;
+export type ResultSelector<
+	R extends SearchResultNodeLike = SearchResultNodeLike,
+> = (cheerio: CheerioAPI, strictSelector: boolean) => R[] | R | null;
 
 /**
  * Search options for single page search


### PR DESCRIPTION
Simple type change to allow custom selectors. custom selectors were implemented in #15 