### PR TITLE
chore: remove uneeded toplevel options

### DIFF
--- a/.changeset/pretty-forks-shout.md
+++ b/.changeset/pretty-forks-shout.md
@@ -1,0 +1,20 @@
+---
+"google-sr": minor
+---
+
+Remove uneeded top level options
+
+
+Removed the `safemode` top-level options as the same result can be achieved using the requestConfig option.
+
+```diff
+const queryResult = await search({
+-    safemode: true,
+    // requestConfig is of type AxiosRequestConfig
++    requestConfig: {
++		params: {
++            // enable "safe mode"
++			safe: 'active'
++		},
++	},
+});

--- a/README.md
+++ b/README.md
@@ -28,38 +28,39 @@ yarn add google-sr
 You can easily perform a single-page search like this:
 
 ```ts
-import { search, OrganicResult } from 'google-sr';
+import { search, OrganicResult, ResultTypes } from 'google-sr';
 
-// using await/async
 const queryResult = await search({
     query: "nodejs",
     // OrganicResult is the default, however it is recommended to always specify the result type
     resultTypes: [OrganicResult],
+    // to add additional configuration to the request, use the requestConfig option
+    // which accepts a AxiosRequestConfig object
+    // OPTIONAL
+    requestConfig: {
+		params: {
+            // enable "safe mode"
+			safe: 'active'
+		},
+	},
 });
 
 // will return a SearchResult[]
 console.log(queryResult);
-// should log: true
-console.log(queryResult[0].type === ResultTypes.OrganicResult)
 ```
 
 To search for multiple pages of results, use the `searchWithPages` function:
 
 ```ts
-import { searchWithPages, OrganicResult } from 'google-sr';
+import { searchWithPages, OrganicResult, ResultTypes } from 'google-sr';
 
-// using await/async
 const queryResult = await searchWithPages({
     query: "nodejs",
     // OrganicResult is the default, however it is recommended to always specify the result type
     resultTypes: [OrganicResult],
     pages: 2,
 });
-
-// will return a SearchResult[][]
 console.log(queryResult);
-// should log: true
-console.log(queryResult[0][0].type === ResultTypes.OrganicResult)
 ```
 
 > By default only `ResultTypes.OrganicResult` result type are returned, use the [resultTypes](#searchoptionsr--resultselector) option to configure it

--- a/apps/examples/package.json
+++ b/apps/examples/package.json
@@ -5,7 +5,8 @@
     "basic": "tsx src/basic.ts",
     "translate": "tsx src/translate.ts",
     "custom-selector": "tsx src/custom-selector.ts",
-    "paged": "tsx src/paged.ts"
+    "paged": "tsx src/paged.ts",
+    "proxies": "tsx src/proxies.ts"
   },
   "type": "module",
   "dependencies": {

--- a/apps/examples/src/proxies.ts
+++ b/apps/examples/src/proxies.ts
@@ -1,0 +1,30 @@
+/**
+ * Demonstrates how to modify the axios request config
+ * via adding proxying requests
+ *
+ * NOTE: This is untested and may not work as expected. It is only provided as an example.
+ *
+ * Main purpose of proxying is to avoid rate limiting issues,
+ * If changing location to receive results from a different location using the
+ * "gl" parameter is BETTER than using a proxy.
+ */
+import { search } from "google-sr";
+
+const results = await search({
+	query: "best coffee shops",
+	// requestConfig is of type AxiosRequestConfig
+	requestConfig: {
+		// to avoid rate limiting issues, use a proxy
+		proxy: {
+			host: "//PROXYHOST",
+			port: 8080,
+		},
+		// if simply wanting to change the location, use the "gl" parameter (geolocation)
+		// instead of changing location via proxy
+		params: {
+			gl: "us",
+		},
+	},
+});
+
+console.log(results);

--- a/packages/google-sr/src/constants.ts
+++ b/packages/google-sr/src/constants.ts
@@ -69,12 +69,6 @@ export interface SearchOptions<R extends ResultSelector = ResultSelector> {
 	 * Search query
 	 */
 	query: string;
-
-	/**
-	 * Toggle to enable google safe mode
-	 */
-	safeMode?: boolean;
-
 	/**
 	 * Control the type of results returned (can have a significant performance impact)
 	 */

--- a/packages/google-sr/src/utils.ts
+++ b/packages/google-sr/src/utils.ts
@@ -53,13 +53,15 @@ export function prepareRequestConfig(opts: SearchOptions): AxiosRequestConfig {
 		: baseHeaders;
 	requestConfig.url = requestConfig.url ?? "https://www.google.com/search";
 
-	requestConfig.params = new URLSearchParams(requestConfig.params);
+	// if params is not a URLSearchParams instance, make it one
+	if (!(requestConfig.params instanceof URLSearchParams)) {
+		requestConfig.params = new URLSearchParams(requestConfig.params);
+	}
+	// these params are always set without being overwritten
 	// set the actual query
 	requestConfig.params.set("q", opts.query);
 	// force the search result to be non javascript
 	requestConfig.params.set("gbv", "1");
-	// safe search
-	if (opts.safeMode === true) requestConfig.params.set("safe", "active");
 
 	// force the response to be text
 	requestConfig.responseType = "text";


### PR DESCRIPTION
Removes the `safemode` top-level options as the same result can be achieved using the `requestConfig` option.
Also adds a proxy example to showcase using `requestConfig`.