### PR TITLE
docs: mention deno install/support in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,54 +1,55 @@
 # google-sr
+
 [![testing workflow](https://github.com/typicalninja/google-sr/actions/workflows/tests.yml/badge.svg)](https://github.com/typicalninja/google-sr)
 [![GitHub issues](https://img.shields.io/github/issues/typicalninja/google-sr)](https://github.com/typicalninja/google-sr/issues)
 [![GitHub Repo stars](https://img.shields.io/github/stars/typicalninja/google-sr)](https://github.com/typicalninja/google-sr/stargazers)
 [![CodeFactor](https://www.codefactor.io/repository/github/typicalninja/google-sr/badge)](https://www.codefactor.io/repository/github/typicalninja/google-sr)
-[![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg)](CODE_OF_CONDUCT.md) 
+[![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg)](CODE_OF_CONDUCT.md)
 [![Discord](https://img.shields.io/discord/807868280387665970)](https://discord.gg/ynwckXS9T2)
 
-Easy to use, updated tools for scraping google search results. 🚀
+Scrape google-sr search results without an API key with javascript/typescript.
 
 # Install
 
-To get started, you can install **google-sr** using your preferred package manager.
-google-sr is tested on following runtimes:
+### Runtime Support
 
-* node.js
-* bun
+`google-sr` does not support web environments, but it has been tested and confirmed to work on the following runtimes:
 
-Other runtimes might work, but are not tested (web is unsupported)
+- [Node.js](https://nodejs.org/en)
+- [Bun](https://bun.sh/)
+- [Deno](https://deno.com/) (with the [`npm:` specifier](https://docs.deno.com/runtime/fundamentals/node/#using-npm-packages))
+
+To get started, you can install **google-sr** using your preferred package manager:
 
 ```bash
 npm install google-sr
-
-[pnpm/yarn/bun] add google-sr
+# For pnpm/yarn/bun:
+pnpm/yarn/bun add google-sr
+# For Deno, the package will be automatically installed when running the script
 ```
 
 # Usage
 
+This example demonstrates some of the features of `google-sr`. For a bare minimum setup, refer to the [examples/basic](https://github.com/typicalninja/google-sr/blob/master/apps/examples/src/basic.ts) file.
+
 ```ts
-import { 
-    search, 
-    // import the result types you want
-    OrganicResult, 
-    DictionaryResult,
-    // helpful to import ResultTypes to filter results
-    ResultTypes 
-} from 'google-sr';
+import {
+  search,
+  OrganicResult, // Import the result types you need
+  DictionaryResult,
+  ResultTypes, // Import to filter results by type
+} from "google-sr";
 
 const queryResult = await search({
-    query: "nodejs",
-    // OrganicResult is the default, however it is recommended to ALWAYS specify the result type
-    resultTypes: [OrganicResult, DictionaryResult],
-    // to add additional configuration to the request, use the requestConfig option
-    // which accepts a AxiosRequestConfig object
-    // OPTIONAL
-    requestConfig: {
-		params: {
-            // enable "safe mode"
-			safe: 'active'
-		},
-	},
+  query: "nodejs",
+  // Specify the result types explicitly ([OrganicResult] is the default, but it is recommended to always specify the result type)
+  resultTypes: [OrganicResult, DictionaryResult],
+  // Optional: Customize the request using AxiosRequestConfig (e.g., enabling safe search)
+  requestConfig: {
+    params: {
+      safe: "active",   // Enable "safe mode"
+    },
+  },
 });
 
 // will return a SearchResult[]
@@ -56,9 +57,9 @@ console.log(queryResult);
 console.log(queryResult[0].type === ResultTypes.OrganicResult); // true
 ```
 
-> **By default only `ResultTypes.OrganicResult` result type are returned, use the `resultTypes` option to configure it**
+> Note: By default, only results of type [`ResultTypes.OrganicResult`](https://github.com/typicalninja/google-sr/blob/master/packages/google-sr/API.md#resulttypes) are returned. Use the [`resultTypes`](https://github.com/typicalninja/google-sr/blob/master/packages/google-sr/API.md#searchoptionsr--resultselector) option to customize the output.
 
-* Additional examples in [apps/examples](https://github.com/typicalninja/google-sr/tree/master/apps/examples) directory
+- Additional examples can be found in [apps/examples](https://github.com/typicalninja/google-sr/tree/master/apps/examples) directory
 
 # google-sr API
 
@@ -67,7 +68,7 @@ Please refer to the google-sr API in [packages/google-sr](https://github.com/typ
 # Monorepo
 
 Welcome to the 📦 monorepo of GSR Project.
- 
+
 🏠 This is the home to google-sr and its related packages & applications.
 
 > **[google-sr](https://github.com/typicalninja/google-sr/blob/master/packages/google-sr)**
@@ -82,31 +83,27 @@ Welcome to the 📦 monorepo of GSR Project.
 [![NPM license for google-sr-selectors](https://img.shields.io/npm/l/google-sr-selectors)](https://www.npmjs.com/package/google-sr-selectors)
 [![npm version for google-sr-selectors](https://img.shields.io/npm/v/google-sr-selectors)](https://www.npmjs.com/package/google-sr-selectors)
 
-
 > **[google-that](https://github.com/typicalninja/google-sr/tree/master/packages/google-that)**
 
 [![npm downloads for google-that](https://img.shields.io/npm/dw/google-that)](https://www.npmjs.com/package/google-that)
 [![NPM license for google-that](https://img.shields.io/npm/l/google-that)](https://www.npmjs.com/package/google-that)
 [![npm version for google-that](https://img.shields.io/npm/v/google-that)](https://www.npmjs.com/package/google-that)
 
-
 This monorepo is managed with [turborepo](https://turbo.build/repo) and uses [pnpm workspaces](https://pnpm.io/workspaces).
-
-# Mirror
-
-GSR project has a mirror repository on codeberg 
-You can find it [here](https://codeberg.org/typicalninja/google-sr)
-
-* All issues and discussion are limited to github & discord
 
 # Disclaimer
 
-This is not sponsored, supported, or affiliated with Google Inc.
+This is not sponsored, supported, or affiliated with Google.
 
-Unlike the conventional recommendation of using the Google API, this module scrapes the Google search result page (which might potentially infringe upon Google's terms of service).
+The source code within this repository is intended solely for **educational & research purposes**.
+The author (typicalninja) & contributors takes **NO** responsibility for any issues that arise from its use, such as IP blocking by Google. Your discretion in usage is advised.
 
-The source code within this repository is intended solely for educational & research purposes.
-The author (typicalninja) & contributors takes **NO** responsibility for any issues that arise from misuse, such as IP blocking by Google. Your discretion in usage is advised.
+# Mirror
+
+GSR project has a mirror repository on codeberg
+You can find it [here](https://codeberg.org/typicalninja/google-sr)
+
+- All issues and discussion are limited to github & discord
 
 # Tests
 

--- a/packages/google-sr-selectors/README.md
+++ b/packages/google-sr-selectors/README.md
@@ -24,21 +24,17 @@ See the [api docs](https://github.com/typicalninja/google-sr/blob/master/package
 
 🌟 Suggest more to be added [here](https://github.com/typicalninja/google-sr/discussions/new?category=ideas)
 
+# Disclaimer
+
+This is not sponsored, supported, or affiliated with Google.
+
+The source code within this repository is intended solely for **educational & research purposes**.
+The author (typicalninja) & contributors takes **NO** responsibility for any issues that arise from its use, such as IP blocking by Google. Your discretion in usage is advised.
+
 # Related projects 🥂
 
 * [google-sr](https://g-sr.vercel.app/google/sr) - Simple tool to programmatically get google search results
 * [google-that](https://g-sr.vercel.app/google/that) - CLI wrapper around google-sr
-
-
-# Disclaimer
-
-This is not sponsored, supported, or affiliated with Google Inc.
-
-Unlike the conventional recommendation of using the Google API, this module scrapes the Google search result page (which might potentially infringe upon Google's terms of service).
-
-The source code within this repository is intended solely for educational & research purposes.
-
-The author (typicalninja) & contributors takes **NO** responsibility for any issues that arise from misuse, such as IP blocking by Google. Your discretion in usage is advised.
 
 # License
 

--- a/packages/google-sr/README.md
+++ b/packages/google-sr/README.md
@@ -12,46 +12,53 @@ Simple & Fast Package for scraping Google search results without the need for an
 
 # Features
 
-* No API key is needed 🔑
-* 1st party typescript support
-* [Customizable selectors](https://github.com/typicalninja/google-sr/blob/master/apps/examples/src/custom-selector.ts) 🔍
-* [Well tested 🔄](#tests)
+- No API key is needed 🔑
+- First-party TypeScript support
+- [Customizable selectors](https://github.com/typicalninja/google-sr/blob/master/apps/examples/src/custom-selector.ts) 🔍
+- [Well tested 🔄](#tests)
+- [Supports multiple runtimes](#runtime-support)
 
 # Install 📦
 
-> google-sr is not supported on browser environments.
+### Runtime Support
+
+`google-sr` does not support web environments, but it has been tested and confirmed to work on the following runtimes:
+
+- [Node.js](https://nodejs.org/en)
+- [Bun](https://bun.sh/)
+- [Deno](https://deno.com/) (with the [`npm:` specifier](https://docs.deno.com/runtime/fundamentals/node/#using-npm-packages))
+
+To get started, you can install **google-sr** using your preferred package manager:
 
 ```bash
 npm install google-sr
-# or other supported runtimes/package managers
-[pnpm/yarn/bun] add google-sr
+# For pnpm/yarn/bun:
+pnpm/yarn/bun add google-sr
+# For Deno, the package will be automatically installed when running the script
 ```
 
 # Usage
 
+This example demonstrates some of the features of `google-sr`. For a bare minimum setup, refer to the [examples/basic](https://github.com/typicalninja/google-sr/blob/master/apps/examples/src/basic.ts) file.
+
 ```ts
-import { 
-    search, 
-    // import the result types you want
-    OrganicResult, 
-    DictionaryResult,
-    // helpful to import ResultTypes to filter results
-    ResultTypes 
-} from 'google-sr';
+import {
+  search,
+  OrganicResult, // Import the result types you need
+  DictionaryResult,
+  ResultTypes, // Import to filter results by type
+} from "google-sr";
 
 const queryResult = await search({
-    query: "nodejs",
-    // OrganicResult is the default, however it is recommended to ALWAYS specify the result type
-    resultTypes: [OrganicResult, DictionaryResult],
-    // to add additional configuration to the request, use the requestConfig option
-    // which accepts a AxiosRequestConfig object
-    // OPTIONAL
-    requestConfig: {
-		params: {
-            // enable "safe mode"
-			safe: 'active'
-		},
-	},
+  query: "nodejs",
+  // Specify the result types explicitly ([OrganicResult] is the default, but it is recommended to always specify the result type)
+  resultTypes: [OrganicResult, DictionaryResult],
+  // Optional: Customize the request using AxiosRequestConfig (e.g., enabling safe search)
+  requestConfig: {
+    params: {
+      safe: "active",   // Enable "safe mode"
+    },
+  },
 });
 
 // will return a SearchResult[]
@@ -59,26 +66,25 @@ console.log(queryResult);
 console.log(queryResult[0].type === ResultTypes.OrganicResult); // true
 ```
 
-> By default only `ResultTypes.OrganicResult` result type are returned, use the [resultTypes](#searchoptionsr--resultselector) option to configure it
+> Note: By default, only results of type [`ResultTypes.OrganicResult`](https://github.com/typicalninja/google-sr/blob/master/packages/google-sr/API.md#resulttypes) are returned. Use the [`resultTypes`](https://github.com/typicalninja/google-sr/blob/master/packages/google-sr/API.md#searchoptionsr--resultselector) option to customize the output.
 
-* Additional examples can be found in [apps/examples](https://github.com/typicalninja/google-sr/tree/master/apps/examples) directory
+- Additional examples can be found in [apps/examples](https://github.com/typicalninja/google-sr/tree/master/apps/examples) directory
 
 # google-sr programatic API
 
 Please refer to the google-sr API in [packages/google-sr](https://github.com/typicalninja/google-sr/blob/master/packages/google-sr/API.md)
 
+# Disclaimer
+
+This is not sponsored, supported, or affiliated with Google.
+
+The source code within this repository is intended solely for **educational & research purposes**.
+The author (typicalninja) & contributors takes **NO** responsibility for any issues that arise from its use, such as IP blocking by Google. Your discretion in usage is advised.
 
 # Related projects 🥂
 
-* [google-that](https://g-sr.vercel.app/google/that) - CLI wrapper around google-sr
-* [google-sr-selectors](https://g-sr.vercel.app/google/selectors) - Selectors for google search results used by google-sr
-
-# ⚠️ Disclaimer
-
-This is not sponsored, supported, or affiliated with Google Inc.
-
-The source code within this repository is intended solely for educational & research purposes.
-The author (typicalninja) & contributors takes **NO** responsibility for any issues that arise from misuse, such as IP blocking by Google. Your discretion in usage is advised.
+- [google-that](https://g-sr.vercel.app/google/that) - CLI wrapper around google-sr
+- [google-sr-selectors](https://g-sr.vercel.app/google/selectors) - Selectors for google search results used by google-sr
 
 # Tests
 

--- a/packages/google-that/README.md
+++ b/packages/google-that/README.md
@@ -10,32 +10,29 @@
 CLI tool to scrape google search results without an api key 🚀.
 This is a demo project to showcase the usage and performance of the [google-sr](https://npmjs.com/package/google-sr) package. google-that is able to output parsed results to a file or to stdout, please check the help page for more info.
 
-## Install 📦
+# Install 📦
 
 To get started, you can install **google-that** using your preferred package manager:
 
-> We suggest you install the package as a global module
+> You can also use `npx` (or similar tools like `pnpm dlx`) to run the tool without needing to install it globally.
 
 ```bash
-
 # npm
 npm install -g google-that
 
-# pnpm 
+# pnpm
 pnpm add -g google-that
 
 # yarn
 yarn add -g google-that
 ```
 
-## Usage
+# Usage
 
 If installation succeeded you can proceed to this step, run the following command in a **NEW** terminal window. it will show you the help page for the tool.
 
 ```bash
-
 google-that --help
-
 ```
 
 ### Example query
@@ -49,23 +46,19 @@ google-that -Q query1 "queries with spaces need to be quoted"
 
 # Writing the results to a file
 google-that -q "Nodejs" -w
-
 ```
-
-# Related projects 🥂
-
-* [google-sr](https://g-sr.vercel.app/google/sr) - Core project used in google-that
-* [google-sr-selectors](https://g-sr.vercel.app/google/selectors) - Selectors for google search results used by google-sr
 
 # Disclaimer
 
-This is not sponsored, supported, or affiliated with Google Inc.
+This is not sponsored, supported, or affiliated with Google.
 
-Unlike the conventional recommendation of using the Google API, this module scrapes the Google search result page (which might potentially infringe upon Google's terms of service).
+The source code within this repository is intended solely for **educational & research purposes**.
+The author (typicalninja) & contributors takes **NO** responsibility for any issues that arise from its use, such as IP blocking by Google. Your discretion in usage is advised.
 
-The source code within this repository is intended solely for educational & research purposes.
+# Related projects 🥂
 
-The author (typicalninja) & contributors takes **NO** responsibility for any issues that arise from misuse, such as IP blocking by Google. Your discretion in usage is advised.
+- [google-sr](https://g-sr.vercel.app/google/sr) - Core project used in google-that
+- [google-sr-selectors](https://g-sr.vercel.app/google/selectors) - Selectors for google search results used by google-sr
 
 # License
 


### PR DESCRIPTION
I have verified the package works on deno with the `npm:` specifier. this adds the note mentioning this. 
The disclaimer was moved bit up for visibility.