### PR TITLE
feat: Add knowledge graph results

### DIFF
--- a/.changeset/fluffy-numbers-provide.md
+++ b/.changeset/fluffy-numbers-provide.md
@@ -1,0 +1,5 @@
+---
+"google-sr": minor
+---
+
+Implement knowledge graph results

--- a/.changeset/giant-books-peel.md
+++ b/.changeset/giant-books-peel.md
@@ -1,0 +1,5 @@
+---
+"google-that": minor
+---
+
+Add support for knowledge graph results

--- a/.changeset/violet-actors-care.md
+++ b/.changeset/violet-actors-care.md
@@ -1,0 +1,5 @@
+---
+"google-sr-selectors": minor
+---
+
+Add selectors for knowledge graph results

--- a/packages/google-sr-selectors/src/index.ts
+++ b/packages/google-sr-selectors/src/index.ts
@@ -39,3 +39,22 @@ export const CurrencyConvertSelector = {
 	from: "span.BNeawe.tAd8D.AP7Wnd > span.r0bn4c.rQMQod",
 	to: "div.BNeawe.iBp4i.AP7Wnd > div > div.BNeawe.iBp4i.AP7Wnd",
 };
+
+export const KnowledgePanelSelector = {
+	title: "div.kCrYT > span.lU7jec > h3.zBAuLc.l97dzf > div.BNeawe",
+	label: "span > div.BNeawe.tAd8D.AP7Wnd",
+	description: "div.BNeawe.s3v9rd.AP7Wnd > div > div.BNeawe.s3v9rd.AP7Wnd",
+	metadataBlock: "div.vbShOe.kCrYT > div.AVsepf > div.BNeawe.s3v9rd.AP7Wnd",
+	metadataLabel: "span > span.BNeawe.s3v9rd.AP7Wnd",
+	metadataValue: "span > span.BNeawe.tAd8D.AP7Wnd",
+	imageSource: "div.idg8be > a.BVG0Nb.OxTOff",
+	// imageUrl is a direct child of the imageSource
+	imageUrl: "div > img.WddBJd",
+
+	catalogBlock: "div:has(> div.kCrYT > span.punez)",
+	catalogTitle: "div.kCrYT > span.punez",
+	catalogItem: "div.Xdlr0d > div.idg8be > a.BVG0Nb.OxTOff > div",
+	catalogItemImage: "div > div.l7d08 > img.h1hFNe",
+	catalogItemTitle: "div > div.RWuggc.kCrYT > div > div.BNeawe.s3v9rd.AP7Wnd",
+	catalogItemCaption: "div > div.RWuggc.kCrYT > div > div.BNeawe.tAd8D.AP7Wnd",
+};

--- a/packages/google-sr/src/constants.ts
+++ b/packages/google-sr/src/constants.ts
@@ -8,7 +8,7 @@ export const ResultTypes = {
 	DictionaryResult: "DICTIONARY",
 	TimeResult: "TIME",
 	CurrencyResult: "CURRENCY",
-	KnowledgePanel: "KNOWLEDGE_PANEL",
+	KnowledgePanelResult: "KNOWLEDGE_PANEL",
 } as const;
 
 // Specific result types returned by gsr
@@ -67,7 +67,7 @@ export interface KnowledgePanelCatalogItem {
 }
 
 export type KnowledgePanelResultNode = ResultNodeTyper<
-	typeof ResultTypes.KnowledgePanel,
+	typeof ResultTypes.KnowledgePanelResult,
 	"label" | "title" | "description"
 > & {
 	metadata: KnowledgePanelMetadata[];

--- a/packages/google-sr/src/constants.ts
+++ b/packages/google-sr/src/constants.ts
@@ -8,6 +8,7 @@ export const ResultTypes = {
 	DictionaryResult: "DICTIONARY",
 	TimeResult: "TIME",
 	CurrencyResult: "CURRENCY",
+	KnowledgePanel: "KNOWLEDGE_PANEL",
 } as const;
 
 // Specific result types returned by gsr
@@ -44,13 +45,44 @@ export type CurrencyResultNode = ResultNodeTyper<
 	"from" | "to"
 >;
 
+export interface KnowledgePanelMetadata {
+	label: string;
+	value: string;
+}
+
+export interface KnowledgePanelImage {
+	source: string;
+	url: string;
+}
+
+export interface KnowledgePanelCatalog {
+	title: string;
+	items: KnowledgePanelCatalogItem[];
+}
+
+export interface KnowledgePanelCatalogItem {
+	title: string;
+	caption: string;
+	image: string;
+}
+
+export type KnowledgePanelResultNode = ResultNodeTyper<
+	typeof ResultTypes.KnowledgePanel,
+	"label" | "title" | "description"
+> & {
+	metadata: KnowledgePanelMetadata[];
+	images: KnowledgePanelImage[];
+	catalog: KnowledgePanelCatalog[];
+};
+
 // All possible result types as a union
 export type SearchResultNode =
 	| OrganicResultNode
 	| TranslateResultNode
 	| DictionaryResultNode
 	| TimeResultNode
-	| CurrencyResultNode;
+	| CurrencyResultNode
+	| KnowledgePanelResultNode;
 
 export interface SearchResultNodeLike {
 	type: string;

--- a/packages/google-sr/src/results.ts
+++ b/packages/google-sr/src/results.ts
@@ -1,6 +1,7 @@
 import {
 	CurrencyConvertSelector,
 	DictionarySearchSelector,
+	KnowledgePanelSelector,
 	OrganicSearchSelector,
 	TimeSearchSelector,
 	TranslateSearchSelector,
@@ -9,6 +10,11 @@ import {
 	type CurrencyResultNode,
 	type DictionaryDefinition,
 	type DictionaryResultNode,
+	type KnowledgePanelCatalog,
+	type KnowledgePanelCatalogItem,
+	type KnowledgePanelImage,
+	type KnowledgePanelMetadata,
+	type KnowledgePanelResultNode,
 	//
 	type OrganicResultNode,
 	type ResultSelector,
@@ -207,5 +213,99 @@ export const CurrencyResult: ResultSelector<CurrencyResultNode> = (
 		type: ResultTypes.CurrencyResult,
 		from: from,
 		to,
+	};
+};
+
+/**
+ * Parses knowledge panel search results.
+ * @param $
+ * @param strictSelector
+ * @returns KnowledgePanelResultNode
+ */
+export const KnowledgePanelResult: ResultSelector<KnowledgePanelResultNode> = (
+	$,
+	strictSelector,
+) => {
+	if (!$) throwNoCheerioError("KnowledgePanel");
+	const title = $(KnowledgePanelSelector.title).text().trim();
+	const description = $(KnowledgePanelSelector.description)
+		.contents()
+		.first()
+		.text()
+		.trim();
+	const label = $(KnowledgePanelSelector.label).text().trim();
+
+	const metadataBlock = $(KnowledgePanelSelector.metadataBlock);
+	const metadata: KnowledgePanelMetadata[] = [];
+
+	for (const element of metadataBlock) {
+		const label = $(element)
+			.find(KnowledgePanelSelector.metadataLabel)
+			.text()
+			.trim();
+		const value = $(element)
+			.find(KnowledgePanelSelector.metadataValue)
+			.text()
+			.trim();
+		if (label && value) metadata.push({ label, value });
+	}
+
+	const imageSource = $(KnowledgePanelSelector.imageSource);
+	const images: KnowledgePanelImage[] = [];
+	for (const element of imageSource) {
+		const source = $(element).attr("href") as string;
+		const url = $(element)
+			.find(KnowledgePanelSelector.imageUrl)
+			.attr("src") as string;
+		if (source && url) {
+			const filteredSource = extractUrlFromGoogleLink(source);
+			if (filteredSource)
+				images.push({ source: filteredSource as string, url });
+		}
+	}
+
+	const catalogBlock = $(KnowledgePanelSelector.catalogBlock);
+	const catalog: KnowledgePanelCatalog[] = [];
+	for (const element of catalogBlock) {
+		const title = $(element)
+			.find(KnowledgePanelSelector.catalogTitle)
+			.text()
+			.trim();
+		const items: KnowledgePanelCatalogItem[] = [];
+		const catalogItems = $(element).find(KnowledgePanelSelector.catalogItem);
+		if (!title || !catalogItems.length) continue;
+		for (const item of catalogItems) {
+			const itemImage = $(item)
+				.find(KnowledgePanelSelector.catalogItemImage)
+				.attr("src") as string;
+			const itemTitle = $(item)
+				.find(KnowledgePanelSelector.catalogItemTitle)
+				.text()
+				.trim();
+			const itemCaption = $(item)
+				.find(KnowledgePanelSelector.catalogItemCaption)
+				.text()
+				.trim();
+			// only itemTitle and itemImage are required
+			if (item && itemImage)
+				items.push({
+					title: itemTitle,
+					image: itemImage,
+					caption: itemCaption,
+				});
+		}
+		if (title && items.length) catalog.push({ title, items });
+	}
+
+	if (isEmpty(strictSelector, title, description, label)) return null;
+
+	return {
+		type: ResultTypes.KnowledgePanel,
+		title,
+		description,
+		label,
+		metadata,
+		images,
+		catalog,
 	};
 };

--- a/packages/google-sr/src/results.ts
+++ b/packages/google-sr/src/results.ts
@@ -15,7 +15,6 @@ import {
 	type KnowledgePanelImage,
 	type KnowledgePanelMetadata,
 	type KnowledgePanelResultNode,
-	//
 	type OrganicResultNode,
 	type ResultSelector,
 	ResultTypes,
@@ -226,7 +225,7 @@ export const KnowledgePanelResult: ResultSelector<KnowledgePanelResultNode> = (
 	$,
 	strictSelector,
 ) => {
-	if (!$) throwNoCheerioError("KnowledgePanel");
+	if (!$) throwNoCheerioError("KnowledgePanelResult");
 	const title = $(KnowledgePanelSelector.title).text().trim();
 	const description = $(KnowledgePanelSelector.description)
 		.contents()
@@ -300,7 +299,7 @@ export const KnowledgePanelResult: ResultSelector<KnowledgePanelResultNode> = (
 	if (isEmpty(strictSelector, title, description, label)) return null;
 
 	return {
-		type: ResultTypes.KnowledgePanel,
+		type: ResultTypes.KnowledgePanelResult,
 		title,
 		description,
 		label,

--- a/packages/google-sr/src/utils.ts
+++ b/packages/google-sr/src/utils.ts
@@ -19,16 +19,21 @@ const baseHeaders = {
  * @private
  */
 export function extractUrlFromGoogleLink(googleLink: string): string | null {
-	// regex to match the part
-	// ! as of 8/9/2023:
-	// following is how the link will look:
-	// * /url?q=https://expressjs.com/&sa=U&ved=2ahUKEwihg46ous-AAxU8XaQEHWwVBxIQFnoECAgQAg&usg=AOvVaw0RwID-oweDOqO2Pg_8gWi1
-	const match = googleLink.match(/\/url\?q=([^&]+)/);
-	if (match) {
-		const decodedUrl = decodeURIComponent(match[1]);
-		return decodedUrl;
+	// Regular expression to extract the `q` or `imgurl` parameter from the link
+	const regex = /[?&](q|imgurl)=([^&]+)/;
+
+	// Match the link against the regex
+	const match = googleLink.match(regex);
+	if (match?.[2]) {
+		try {
+			// Decode the extracted URL to handle encoded characters
+			return decodeURIComponent(match[2]);
+		} catch {
+			// Return null if decoding fails
+			return null;
+		}
 	}
-	// link could not be parsed
+	// Return null if no match is found
 	return null;
 }
 

--- a/packages/google-sr/tests/result.test.ts
+++ b/packages/google-sr/tests/result.test.ts
@@ -2,6 +2,7 @@ import { expect, test } from "vitest";
 import {
 	CurrencyResult,
 	DictionaryResult,
+	KnowledgePanelResult,
 	OrganicResult,
 	ResultTypes,
 	TimeResult,
@@ -121,4 +122,58 @@ test("Search for time results", async () => {
 		expect(result.location).to.be.a("string").and.not.empty;
 		expect(result.timeInWords).to.be.a("string").and.not.empty;
 	}
+});
+
+test("Search for Knowledge panel results", async () => {
+	const queryResult = await search({
+		// just a great movie
+		query: "Interstellar",
+		resultTypes: [KnowledgePanelResult],
+	});
+	// only one result should be returned for this query
+	expect(queryResult).toHaveLength(1);
+	// only 1 result expected
+	const result = queryResult[0];
+	// validate base data
+	expect(result.title).to.be.a("string");
+	expect(result.description).to.be.a("string");
+
+	// validate metadata
+	for (const meta of result.metadata) {
+		expect(meta.label).to.be.a("string");
+		expect(meta.value).to.be.a("string");
+	}
+
+	const meta1 = result.metadata[0];
+	// validate 1st metadata, if 1st is correct, others should be correct too
+	expect(meta1.label).toBe("Release date");
+	expect(meta1.value).toBe("October 26, 2014 (USA)");
+
+	// validate images
+	for (const image of result.images) {
+		expect(image.source).to.be.a("string");
+		expect(image.url).to.be.a("string");
+		// validate urls
+		expect(image.url).to.match(/^https?:\/\//);
+		expect(image.source).to.match(/^https?:\/\//);
+	}
+
+	// validate catalog
+	for (const catalog of result.catalog) {
+		expect(catalog.title).to.be.a("string");
+		// validate each item in catalog
+		for (const item of catalog.items) {
+			expect(item.title).to.be.a("string");
+			expect(item.image).to.be.a("string");
+			expect(item.image).to.match(/^https?:\/\//);
+			expect(item.caption).to.be.a("string");
+		}
+	}
+
+	// validate 1st catalog
+	const catalog1 = result.catalog[0];
+	expect(catalog1.title).toBe("Cast");
+	const item1 = catalog1.items[0];
+	expect(item1.title).toBe("Matthew McConaughey");
+	expect(item1.caption).toBe("Cooper");
 });

--- a/packages/google-that/src/helpers.ts
+++ b/packages/google-that/src/helpers.ts
@@ -1,6 +1,7 @@
 import {
 	CurrencyResult,
 	DictionaryResult,
+	KnowledgePanelResult,
 	OrganicResult,
 	type ResultSelector,
 	ResultTypes,
@@ -42,6 +43,8 @@ export function selectorTypeToSelector(selector: string): ResultSelector {
 			return DictionaryResult;
 		case ResultTypes.CurrencyResult:
 			return CurrencyResult;
+		case ResultTypes.KnowledgePanelResult:
+			return KnowledgePanelResult;
 		default:
 			throw new Error(`Unknown selector type: ${selector}`);
 	}


### PR DESCRIPTION
This pr implements support for knowledge graph results.
Query example: ["Interstellar"](https://www.google.com/search?hl=en&q=Interstellar) should return information about the movie in a separate panel.