### PR TITLE
refactor: patch translation selectors

### DIFF
--- a/.changeset/smart-clouds-own.md
+++ b/.changeset/smart-clouds-own.md
@@ -1,0 +1,5 @@
+---
+"google-sr-selectors": patch
+---
+
+patch the translate search result selectors

--- a/packages/google-sr-selectors/src/index.ts
+++ b/packages/google-sr-selectors/src/index.ts
@@ -6,8 +6,8 @@ export const OrganicSearchSelector = {
 };
 
 export const TranslateSearchSelector = {
-	sourceLanguage: "#tsuid_2 option:selected",
-	targetLanguage: "#tsuid_4 option:selected",
+	sourceLanguage: "select.J9hCCd[name='tlitesl'] > option:selected",
+	targetLanguage: "select.J9hCCd[name='tlitetl'] > option:selected",
 	translationText: '[id="lrtl-translation-text"]',
 	sourceText: '#lrtl-source-text input[name="tlitetxt"]',
 	pronunciation: '[id="lrtl-transliteration-text"]',


### PR DESCRIPTION
There were some recent changes to how google sends the result for translations. the selects for target & source langs now contain dynamic ids. instead we are now relying on a static id property.