### PR TITLE
refactor: bypass JavaScript requirement for Google search

### DIFF
--- a/.changeset/chilly-yaks-kick.md
+++ b/.changeset/chilly-yaks-kick.md
@@ -1,0 +1,21 @@
+---
+"google-sr": major
+---
+
+Bypass JavaScript requirement for Google search
+
+In a recent Google update, the ability to access search result pages without enabling JavaScript was disabled. 
+(See [#51](https://github.com/typicalninja/google-sr/issues/51) for more details.)
+
+A workaround that bypasses the JavaScript requirement by utilizing an alternate page version served to specific user agents
+is now implemented. However, this alternate page lacks certain 
+features available on the standard page, resulting in the removal of some properties.
+
+#### Changes to results
+
+* `OrganicResult` - No user facing changes
+* `TranslateResult` - `translationPronunciation` property was removed
+* `DictionaryResult` - `definition` property was removed in favour of a `meaning` property, check the documentation for more details
+* `CurrencyResult` - No user facing changes
+* `TimeResult` - No user facing changes
+* `KnowledgePanelResult` - `images` and `catalog` properties were removed, new properties `sourceLink` and `imageLink` were added.

--- a/.changeset/cold-masks-bathe.md
+++ b/.changeset/cold-masks-bathe.md
@@ -1,0 +1,32 @@
+---
+"google-sr-selectors": major
+---
+
+Update dictionary result selectors
+
+Following selectors were replaced with new ones / removed.
+
+```json5
+{
+  audio: "...",
+  definition: "...",
+  definitionPartOfSpeech: "...",
+  definitionExample: "...",
+  definitionSynonyms: "..."
+}
+```
+
+The following selectors are the replacement for the above selectors.
+
+```json5
+{
+  definitionsContainer: "...",
+  // container has multiple of these blocks
+  definitionsBlock: "...",
+  // within a definition block
+  definitionPartOfSpeech: "...",
+  definitionList: "...",
+  // the selector for synonyms and examples are the same
+  definitionTextBlock: "...",
+}
+```

--- a/.changeset/olive-panthers-sin.md
+++ b/.changeset/olive-panthers-sin.md
@@ -2,10 +2,21 @@
 "google-sr-selectors": major
 ---
 
-Fix Translate Search Result Selectors
+Update translate result selectors
 
-This patch resolves issues caused by Google disabling access to search results without JavaScript. Users of `google-sr` will be minimally impacted by this change. For those using `google-sr-selectors`, refer to the `google-sr` source for details on how to use the updated selectors.  
+Following selectors were replaced with new ones / removed.
 
-This update is classified as a major change because it removes several properties, such as `pronunciation` (etc..), which are unavailable in the older version of the search results page (which we use as a bypass).  
+```json5
+{
 
-For more details, see the relevant GitHub issue: [#51](https://github.com/typicalninja/google-sr/issues/51).
+  translationText: "...",
+  sourceLanguage: "...",
+  targetLanguage: "...",
+}
+```
+
+The following selectors are the replacement for the above selectors.
+
+* `translateFromTo` -> `sourceLanguage` and `targetLanguage`
+   * translateFromTo is a string in the format of `sourceLanguage to targetLanguage`
+* `translatedText` -> `translationText`

--- a/.changeset/olive-panthers-sin.md
+++ b/.changeset/olive-panthers-sin.md
@@ -1,0 +1,11 @@
+---
+"google-sr-selectors": major
+---
+
+Fix Translate Search Result Selectors
+
+This patch resolves issues caused by Google disabling access to search results without JavaScript. Users of `google-sr` will be minimally impacted by this change. For those using `google-sr-selectors`, refer to the `google-sr` source for details on how to use the updated selectors.  
+
+This update is classified as a major change because it removes several properties, such as `pronunciation` (etc..), which are unavailable in the older version of the search results page (which we use as a bypass).  
+
+For more details, see the relevant GitHub issue: [#51](https://github.com/typicalninja/google-sr/issues/51).

--- a/.changeset/selfish-comics-give.md
+++ b/.changeset/selfish-comics-give.md
@@ -1,0 +1,5 @@
+---
+"google-sr-selectors": patch
+---
+
+Patch currency and time result selectors

--- a/.changeset/serious-walls-turn.md
+++ b/.changeset/serious-walls-turn.md
@@ -1,0 +1,9 @@
+---
+"google-sr": major
+---
+
+Fix translate search results
+
+This patch resolves issues caused by Google disabling access to search results without JavaScript. It incorporates changes from `google-sr-selectors`. Several properties, such as `pronunciation` (etc..), are unavailable in the older version of the search results page (which we use as a bypass), and thus have been removed.
+
+For more details, see the relevant GitHub issue: [#51](https://github.com/typicalninja/google-sr/issues/51).

--- a/.changeset/serious-walls-turn.md
+++ b/.changeset/serious-walls-turn.md
@@ -1,9 +1,36 @@
 ---
-"google-sr": major
+"google-sr-selectors": major
 ---
 
-Fix translate search results
+Update knowledge panel result selectors
 
-This patch resolves issues caused by Google disabling access to search results without JavaScript. It incorporates changes from `google-sr-selectors`. Several properties, such as `pronunciation` (etc..), are unavailable in the older version of the search results page (which we use as a bypass), and thus have been removed.
+Following selectors are no longer available.
 
-For more details, see the relevant GitHub issue: [#51](https://github.com/typicalninja/google-sr/issues/51).
+```json5
+{
+    catalogBlock: "...", 
+    catalogTitle: "...",
+    catalogItem: "...",
+    catalogItemImage: "...",
+    catalogItemTitle: "...",    
+    catalogItemCaption: "...",
+}
+```
+
+Following selectors have some changes on how they are used (or new).
+
+```json5
+{
+  // Direct children of the first element 
+  // obtained via the `headerBlock` selector.
+  title: "...",
+  label: "...",
+  // This is a child of the second element 
+  // obtained via `headerBlock` selector
+  imageUrl: "...",
+  // description block contains description and metadata (description source link)
+  // the first span is the description
+  // and the first "<a>" is the source link
+  descriptionBlock: "...",
+}
+```

--- a/.changeset/sour-bears-visit.md
+++ b/.changeset/sour-bears-visit.md
@@ -2,10 +2,13 @@
 "google-sr-selectors": major
 ---
 
-Fix dictionary search results
+Update organic search result selectors
 
-This patch resolves issues caused by Google disabling access to search results without JavaScript. Users of `google-sr` will be minimally impacted by this change. For those using `google-sr-selectors`, refer to the `google-sr` source for details on how to use the updated selectors.
+Following selectors were moved to a separate `GeneralSelector`, 
+other usages stay similar
 
-This update is classified as a major change because it removes several properties and drastically change others, such as `audio` (etc..), which are unavailable in the older version of the search results page (which we use as a bypass).
-
-For more details, see the relevant GitHub issue: [#51](https://github.com/typicalninja/google-sr/issues/51).
+```json5
+{
+  block: ""
+}
+```

--- a/.changeset/sour-bears-visit.md
+++ b/.changeset/sour-bears-visit.md
@@ -1,0 +1,11 @@
+---
+"google-sr-selectors": major
+---
+
+Fix dictionary search results
+
+This patch resolves issues caused by Google disabling access to search results without JavaScript. Users of `google-sr` will be minimally impacted by this change. For those using `google-sr-selectors`, refer to the `google-sr` source for details on how to use the updated selectors.
+
+This update is classified as a major change because it removes several properties and drastically change others, such as `audio` (etc..), which are unavailable in the older version of the search results page (which we use as a bypass).
+
+For more details, see the relevant GitHub issue: [#51](https://github.com/typicalninja/google-sr/issues/51).

--- a/apps/examples/src/translate.ts
+++ b/apps/examples/src/translate.ts
@@ -24,5 +24,5 @@ if (!translated) {
 }
 
 console.log(
-	`"${translated.sourceText}" in ${translated.sourceLanguage} translated to ${translated.translationLanguage} is "${translated.translationText}"`,
+	`"${translated.sourceText}" in ${translated.sourceLanguage} translated to ${translated.translationLanguage} is "${translated.translatedText}"`,
 );

--- a/apps/scraper/search-dump.js
+++ b/apps/scraper/search-dump.js
@@ -39,7 +39,7 @@ try {
 	console.log(`Request success > received ${queryRequest.data.length} bytes`);
 	const $ = cheerio.load(queryRequest.data);
 
-	const mainContent = $("#main");
+	const mainContent = $("html");
 	// filter out uneeded parts
 	mainContent.find("footer, header, script, svg, style, #st-card").remove();
 

--- a/apps/scraper/search-dump.js
+++ b/apps/scraper/search-dump.js
@@ -29,12 +29,10 @@ try {
 			referer: "https://www.google.com/",
 			"upgrade-insecure-requests": 1,
 			"User-Agent":
-				"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/103.0.0.0 Safari/537.36",
+				"Links (2.29; Linux 6.11.0-13-generic x86_64; GNU C 13.2; text)",
 		},
 		params: {
 			q: query,
-			// required to get the non-js version of the page
-			gbv: "1",
 		},
 		responseType: "text",
 	});

--- a/packages/google-sr-selectors/README.md
+++ b/packages/google-sr-selectors/README.md
@@ -1,6 +1,5 @@
 # google-sr-selectors
 
-
 [![testing workflow](https://github.com/typicalninja/google-sr/actions/workflows/tests.yml/badge.svg)](https://github.com/typicalninja/google-sr)
 [![npm downloads](https://img.shields.io/npm/dw/google-sr-selectors)](https://www.npmjs.com/package/google-sr-selectors)
 [![GitHub issues](https://img.shields.io/github/issues/typicalninja/google-sr)](https://github.com/typicalninja/google-sr/issues)
@@ -9,20 +8,18 @@
 [![Discord](https://img.shields.io/discord/807868280387665970)](https://discord.gg/ynwckXS9T2)
 [![CodeFactor](https://www.codefactor.io/repository/github/typicalninja/google-sr/badge)](https://www.codefactor.io/repository/github/typicalninja/google-sr)
 
-Set of html selectors for parsing google search results with jquery like modules (ex: cheerio).
+**For simple use cases, refer to [google-sr](https://github.com/typicalninja/google-sr/tree/master/packages/google-sr)**
 
-Please note that the included selectors are intended for the **non-Javascript** version of Google Search page. 
-These were obtained by appending `&gbv=1` to the regular query link.
+This package provides a set of CSS selectors for parsing Google search results, using tools such as [cheerio](https://github.com/cheeriojs/cheerio), etc...
 
-ex: (disable javascript, else it will redirect): [query `nodejs`](https://www.google.com/search?hl=en&q=nodejs&gbv=1)
+These selectors are compatible only with the search results page returned when the following user-agent is used:
+`Links (2.29; Linux 6.11.0-13-generic x86_64; GNU C 13.2; text)`.
 
-# Supported types
-
-The package currently only supports a limited amount search result types
-
-See the [api docs](https://github.com/typicalninja/google-sr/blob/master/packages/google-sr-selectors/API.md) for more information.
-
-🌟 Suggest more to be added [here](https://github.com/typicalninja/google-sr/discussions/new?category=ideas)
+#### Important Note:
+Due to the constantly evolving nature of Google's search page structure, we cannot guarantee consistent 
+usage/validity of these selectors. Unless you are an advanced user with specific requirements, **we highly recommend 
+using the [google-sr](https://github.com/typicalninja/google-sr/tree/master/packages/google-sr) package instead** of 
+relying directly on google-sr-selectors.
 
 # Disclaimer
 
@@ -30,6 +27,14 @@ This is not sponsored, supported, or affiliated with Google.
 
 The source code within this repository is intended solely for **educational & research purposes**.
 The author (typicalninja) & contributors takes **NO** responsibility for any issues that arise from its use, such as IP blocking by Google. Your discretion in usage is advised.
+
+# Links
+
+- [API Documentation](https://typicalninja.github.io/google-sr)
+- [GitHub Repository](https://github.com/typicalninja/google-sr)
+- [NPM Package](https://www.npmjs.com/package/google-sr-selectors)
+- [Discord](https://discord.gg/ynwckXS9T2)
+
 
 # Related projects 🥂
 

--- a/packages/google-sr-selectors/package.json
+++ b/packages/google-sr-selectors/package.json
@@ -10,7 +10,8 @@
     "import": "./dist/index.mjs"
   },
   "scripts": {
-    "build": "tsup"
+    "build": "tsup",
+    "dev": "tsup --watch"
   },
   "keywords": [
     "google-sr",

--- a/packages/google-sr-selectors/src/index.ts
+++ b/packages/google-sr-selectors/src/index.ts
@@ -16,19 +16,22 @@ export const TranslateSearchSelector = {
 };
 
 export const DictionarySearchSelector = {
-	// use attr('src') to get the audio url
-	audio: "h3.zBAuLc.l97dzf > div.BNeawe > audio",
-	phonetic: "span > div.BNeawe.tAd8D.AP7Wnd",
-	word: "span.lU7jec > h3.zBAuLc.l97dzf > div.BNeawe",
+	block: "div > div.ezO2md",
+	phonetic: "td > span.qXLe6d.F9iS2e > span",
+	word: "td > span.qXLe6d.x3G5ab > span.fYyStc",
 	// there can be multiple definitions
-	// use definitionPartOfSpeech as reference to how many definitions there are
-	// there are no reliable way other than that to get definitions
-	definition: "div.v9i61e > div.BNeawe.s3v9rd.AP7Wnd:not(:has(span))",
-	definitionPartOfSpeech:
-		"div.Ap5OSd > div.BNeawe.s3v9rd.AP7Wnd > span.r0bn4c.rQMQod",
-	definitionExample: "div.v9i61e > div.BNeawe.s3v9rd.AP7Wnd:has(span)",
-	definitionSynonyms:
-		"div:not(.v9i61e):not(.Ap5OSd) > div.BNeawe.s3v9rd.AP7Wnd > span.r0bn4c.rQMQod",
+	// use definitionPartOfSpeech as reference to how many definitions
+	// there are no reliable ways other than that to get definitions
+	// the main container
+	definitionsContainer: "div.AS66f",
+	// container has multiple of these blocks
+	definitionsBlock: "div.CSfvHb",
+	// within each definition block
+	definitionPartOfSpeech: "span.qXLe6d.FrIlee > span.fYyStc.YVIcad",
+	definitionList: "div.CSfvHb > ol > li",
+	// each li contains multiple spans (TextBlocks)
+	// the selector for synonyms and examples are the same
+	definitionTextBlock: "span.qXLe6d.FrIlee > span.fYyStc",
 };
 
 export const TimeSearchSelector = {

--- a/packages/google-sr-selectors/src/index.ts
+++ b/packages/google-sr-selectors/src/index.ts
@@ -1,13 +1,17 @@
+export const GeneralSelector = {
+	// almost all results are within same structured container
+	// data-hveid attr blocks are for time search selectors
+	block: "div:not([data-hveid]) > div.ezO2md",
+};
+
 export const OrganicSearchSelector = {
-	block: "div > div.ezO2md",
 	link: "div > div > a.fuLhoc.ZWRArf",
 	title: "span.CVA68e.qXLe6d.fuLhoc.ZWRArf",
 	description: "span.qXLe6d.FrIlee > span.fYyStc",
 };
 
 export const TranslateSearchSelector = {
-	block: "div > div.ezO2md",
-	// old version does not have seperate source and target language
+	// old version does not have separate source and target language
 	// instead it has ex "English (detected) to Spanish "
 	translateFromTo: "div.kk667b > span.FrIlee > span.fYyStc",
 	translatedText: "td > div > div > span.qXLe6d.epoveb > span.fYyStc",
@@ -16,7 +20,6 @@ export const TranslateSearchSelector = {
 };
 
 export const DictionarySearchSelector = {
-	block: "div > div.ezO2md",
 	phonetic: "td > span.qXLe6d.F9iS2e > span",
 	word: "td > span.qXLe6d.x3G5ab > span.fYyStc",
 	// there can be multiple definitions
@@ -26,15 +29,16 @@ export const DictionarySearchSelector = {
 	definitionsContainer: "div.AS66f",
 	// container has multiple of these blocks
 	definitionsBlock: "div.CSfvHb",
-	// within each definition block
+	// within a definition block
 	definitionPartOfSpeech: "span.qXLe6d.FrIlee > span.fYyStc.YVIcad",
 	definitionList: "div.CSfvHb > ol > li",
-	// each li contains multiple spans (TextBlocks)
 	// the selector for synonyms and examples are the same
 	definitionTextBlock: "span.qXLe6d.FrIlee > span.fYyStc",
 };
 
 export const TimeSearchSelector = {
+	// slightly specific selector
+	block: "div[data-hveid] > div.ezO2md",
 	location: "span.BNeawe.tAd8D.AP7Wnd > span.r0bn4c.rQMQod",
 	time: "div.BNeawe.iBp4i.AP7Wnd > div > div.BNeawe.iBp4i.AP7Wnd",
 	timeInWords: "div.BNeawe.tAd8D.AP7Wnd > div > div.BNeawe.tAd8D.AP7Wnd",

--- a/packages/google-sr-selectors/src/index.ts
+++ b/packages/google-sr-selectors/src/index.ts
@@ -6,11 +6,13 @@ export const OrganicSearchSelector = {
 };
 
 export const TranslateSearchSelector = {
-	sourceLanguage: "select.J9hCCd[name='tlitesl'] > option:selected",
-	targetLanguage: "select.J9hCCd[name='tlitetl'] > option:selected",
-	translationText: '[id="lrtl-translation-text"]',
-	sourceText: '#lrtl-source-text input[name="tlitetxt"]',
-	pronunciation: '[id="lrtl-transliteration-text"]',
+	block: "div > div.ezO2md",
+	// old version does not have seperate source and target language
+	// instead it has ex "English (detected) to Spanish "
+	translateFromTo: "div.kk667b > span.FrIlee > span.fYyStc",
+	translatedText: "td > div > div > span.qXLe6d.epoveb > span.fYyStc",
+	// source text is in the format "hello" in Japanese
+	sourceText: "td > div > div > span.qXLe6d.F9iS2e > span.fYyStc",
 };
 
 export const DictionarySearchSelector = {

--- a/packages/google-sr-selectors/src/index.ts
+++ b/packages/google-sr-selectors/src/index.ts
@@ -1,8 +1,8 @@
 export const OrganicSearchSelector = {
-	block: "div:not([data-hveid]):not(.yStFkb) > div.Gx5Zad.xpd.EtOod.pkphOe",
-	link: "[data-ved]",
-	title: "h3.zBAuLc",
-	description: ".BNeawe.s3v9rd.AP7Wnd",
+	block: "div > div.ezO2md",
+	link: "div > div > a.fuLhoc.ZWRArf",
+	title: "span.CVA68e.qXLe6d.fuLhoc.ZWRArf",
+	description: "span.qXLe6d.FrIlee > span.fYyStc",
 };
 
 export const TranslateSearchSelector = {

--- a/packages/google-sr-selectors/src/index.ts
+++ b/packages/google-sr-selectors/src/index.ts
@@ -37,14 +37,17 @@ export const DictionarySearchSelector = {
 };
 
 export const TimeSearchSelector = {
-	// slightly specific selector
-	block: "div[data-hveid] > div.ezO2md",
-	location: "span.BNeawe.tAd8D.AP7Wnd > span.r0bn4c.rQMQod",
-	time: "div.BNeawe.iBp4i.AP7Wnd > div > div.BNeawe.iBp4i.AP7Wnd",
-	timeInWords: "div.BNeawe.tAd8D.AP7Wnd > div > div.BNeawe.tAd8D.AP7Wnd",
+	block: "div[data-hveid] > div.ezO2md > div",
+	location: "div.kk667b > span.F9iS2e > span.fYyStc.YVIcad",
+	// the time and tiw is within a table for layouting
+	// this makes it efficient the container before taking the actual content itself
+	timeLayoutTable: "table.Mw6wOc > tbody > tr > td > div",
+	time: "div > span.qXLe6d.epoveb > span.fYyStc",
+	timeInWords: "div > span.qXLe6d.F9iS2e > span.fYyStc.YVIcad",
 };
 
 export const CurrencyConvertSelector = {
+	block: "div[data-hveid] > div.ezO2md",
 	from: "span.BNeawe.tAd8D.AP7Wnd > span.r0bn4c.rQMQod",
 	to: "div.BNeawe.iBp4i.AP7Wnd > div > div.BNeawe.iBp4i.AP7Wnd",
 };

--- a/packages/google-sr-selectors/src/index.ts
+++ b/packages/google-sr-selectors/src/index.ts
@@ -52,20 +52,18 @@ export const CurrencyConvertSelector = {
 };
 
 export const KnowledgePanelSelector = {
-	title: "div.kCrYT > span.lU7jec > h3.zBAuLc.l97dzf > div.BNeawe",
-	label: "span > div.BNeawe.tAd8D.AP7Wnd",
-	description: "div.BNeawe.s3v9rd.AP7Wnd > div > div.BNeawe.s3v9rd.AP7Wnd",
-	metadataBlock: "div.vbShOe.kCrYT > div.AVsepf > div.BNeawe.s3v9rd.AP7Wnd",
-	metadataLabel: "span > span.BNeawe.s3v9rd.AP7Wnd",
-	metadataValue: "span > span.BNeawe.tAd8D.AP7Wnd",
-	imageSource: "div.idg8be > a.BVG0Nb.OxTOff",
-	// imageUrl is a direct child of the imageSource
-	imageUrl: "div > img.WddBJd",
+	headerBlock: "table.ZuwI5d > tbody > tr > td",
+	// the headerBlock contains title and label
+	title: "span.qXLe6d.x3G5ab > span.fYyStc",
+	label: "span.qXLe6d.F9iS2e > span.fYyStc",
+	// the second td contains the image
+	imageUrl: "a > img.qPa7sb",
+	// description block contains description and metadata (description source link)
+	// the first span is the description
+	// and the first "<a>" is the source link
+	descriptionBlock: "div.AS66f > div > span.qXLe6d.FrIlee",
 
-	catalogBlock: "div:has(> div.kCrYT > span.punez)",
-	catalogTitle: "div.kCrYT > span.punez",
-	catalogItem: "div.Xdlr0d > div.idg8be > a.BVG0Nb.OxTOff > div",
-	catalogItemImage: "div > div.l7d08 > img.h1hFNe",
-	catalogItemTitle: "div > div.RWuggc.kCrYT > div > div.BNeawe.s3v9rd.AP7Wnd",
-	catalogItemCaption: "div > div.RWuggc.kCrYT > div > div.BNeawe.tAd8D.AP7Wnd",
+	metadataBlock: "div.omMllc",
+	metadataLabel: "span.FrIlee > span.fYyStc",
+	metadataValue: "span.F9iS2e",
 };

--- a/packages/google-sr-selectors/src/index.ts
+++ b/packages/google-sr-selectors/src/index.ts
@@ -47,9 +47,8 @@ export const TimeSearchSelector = {
 };
 
 export const CurrencyConvertSelector = {
-	block: "div[data-hveid] > div.ezO2md",
-	from: "span.BNeawe.tAd8D.AP7Wnd > span.r0bn4c.rQMQod",
-	to: "div.BNeawe.iBp4i.AP7Wnd > div > div.BNeawe.iBp4i.AP7Wnd",
+	from: "div > div.kk667b > span.F9iS2e > span.fYyStc.YVIcad",
+	to: "div > table.Mw6wOc > tbody > tr > td > div.fBgPuf > div > span.qXLe6d.epoveb > span.fYyStc",
 };
 
 export const KnowledgePanelSelector = {

--- a/packages/google-sr/README.md
+++ b/packages/google-sr/README.md
@@ -26,7 +26,7 @@ Simple & Fast Package for scraping Google search results without the need for an
 
 - [Node.js](https://nodejs.org/en)
 - [Bun](https://bun.sh/)
-- [Deno](https://deno.com/) (with the [`npm:` specifier](https://docs.deno.com/runtime/fundamentals/node/#using-npm-packages))
+- [Deno](https://deno.com/)
 
 To get started, you can install **google-sr** using your preferred package manager:
 
@@ -72,16 +72,19 @@ console.log(queryResult[0].type === ResultTypes.OrganicResult); // true
 
 - Additional examples can be found in [apps/examples](https://github.com/typicalninja/google-sr/tree/master/apps/examples) directory
 
-# google-sr API
-
-Please refer to the google-sr API [here](https://typicalninja.github.io/google-sr/)
-
 # Disclaimer
 
 This is not sponsored, supported, or affiliated with Google.
 
 The source code within this repository is intended solely for **educational & research purposes**.
 The author (typicalninja) & contributors takes **NO** responsibility for any issues that arise from its use, such as IP blocking by Google. Your discretion in usage is advised.
+
+# Links
+
+- [API Documentation](https://typicalninja.github.io/google-sr)
+- [GitHub Repository](https://github.com/typicalninja/google-sr)
+- [NPM Package](https://www.npmjs.com/package/google-sr) 
+- [Discord](https://discord.gg/ynwckXS9T2)
 
 # Related projects 🥂
 

--- a/packages/google-sr/package.json
+++ b/packages/google-sr/package.json
@@ -11,7 +11,8 @@
   },
   "scripts": {
     "test": "vitest",
-    "build": "tsup"
+    "build": "tsup",
+    "dev": "tsup --watch"
   },
   "keywords": [
     "google-sr",

--- a/packages/google-sr/src/constants.ts
+++ b/packages/google-sr/src/constants.ts
@@ -20,17 +20,23 @@ export type TranslateResultNode = ResultNodeTyper<
 	typeof ResultTypes.TranslateResult,
 	"sourceLanguage" | "translationLanguage" | "sourceText" | "translatedText"
 >;
+
 export interface DictionaryDefinition {
-	partOfSpeech: string;
-	definition: string;
-	example: string;
-	synonyms: string[];
+	definition: string; // The definition text
+	example?: string; // An example sentence using the word
+	synonyms?: string[]; // List of synonyms for this definition
 }
+
+export interface DictionaryMeaning {
+	partOfSpeech: string; // The part of speech (e.g., "noun", "verb")
+	definitions: DictionaryDefinition[]; // Array of definitions for this part of speech
+}
+
 // Dictionary result contains a special property called definitions which is an array
 export type DictionaryResultNode = ResultNodeTyper<
 	typeof ResultTypes.DictionaryResult,
-	"audio" | "phonetic" | "word"
-> & { definitions: DictionaryDefinition[] };
+	"phonetic" | "word"
+> & { meanings: DictionaryMeaning[] };
 
 export type TimeResultNode = ResultNodeTyper<
 	typeof ResultTypes.TimeResult,

--- a/packages/google-sr/src/constants.ts
+++ b/packages/google-sr/src/constants.ts
@@ -18,11 +18,7 @@ export type OrganicResultNode = ResultNodeTyper<
 >;
 export type TranslateResultNode = ResultNodeTyper<
 	typeof ResultTypes.TranslateResult,
-	| "sourceLanguage"
-	| "translationLanguage"
-	| "sourceText"
-	| "translationText"
-	| "translationPronunciation"
+	"sourceLanguage" | "translationLanguage" | "sourceText" | "translatedText"
 >;
 export interface DictionaryDefinition {
 	partOfSpeech: string;
@@ -140,3 +136,6 @@ export interface SearchOptionsWithPages<
 	 */
 	delay?: number;
 }
+
+// source text is in the format "hello" in Japanese, we need to select the text between ""
+export const TranslateSourceTextRegex = /"(.+?)"/;

--- a/packages/google-sr/src/constants.ts
+++ b/packages/google-sr/src/constants.ts
@@ -52,29 +52,11 @@ export interface KnowledgePanelMetadata {
 	value: string;
 }
 
-export interface KnowledgePanelImage {
-	source: string;
-	url: string;
-}
-
-export interface KnowledgePanelCatalog {
-	title: string;
-	items: KnowledgePanelCatalogItem[];
-}
-
-export interface KnowledgePanelCatalogItem {
-	title: string;
-	caption: string;
-	image: string;
-}
-
 export type KnowledgePanelResultNode = ResultNodeTyper<
 	typeof ResultTypes.KnowledgePanelResult,
-	"label" | "title" | "description"
+	"label" | "title" | "description" | "sourceLink" | "imageLink"
 > & {
 	metadata: KnowledgePanelMetadata[];
-	images: KnowledgePanelImage[];
-	catalog: KnowledgePanelCatalog[];
 };
 
 // All possible result types as a union

--- a/packages/google-sr/src/results.ts
+++ b/packages/google-sr/src/results.ts
@@ -270,9 +270,13 @@ export const CurrencyResult: ResultSelector<CurrencyResultNode> = (
 	strictSelector,
 ) => {
 	if (!$) throwNoCheerioError("CurrencyResult");
-	const from = $(CurrencyConvertSelector.from).text().replace("=", "").trim();
-	const to = $(CurrencyConvertSelector.to).text().trim();
-
+	const block = $(GeneralSelector.block).first();
+	const from = block
+		.find(CurrencyConvertSelector.from)
+		.text()
+		.replace("=", "")
+		.trim();
+	const to = block.find(CurrencyConvertSelector.to).text().trim();
 	if (isEmpty(strictSelector, from, to)) return null;
 
 	return {

--- a/packages/google-sr/src/results.ts
+++ b/packages/google-sr/src/results.ts
@@ -78,7 +78,9 @@ export const TranslateResult: ResultSelector<TranslateResultNode> = (
 	if (!translateBlock) return null;
 	// old version does not have seperate source and target language
 	// instead it has ex "English (detected) to Spanish "
-	const translatedFromTo = $(TranslateSearchSelector.translateFromTo).text();
+	const translatedFromTo = translateBlock
+		.find(TranslateSearchSelector.translateFromTo)
+		.text();
 	const fromTo = translatedFromTo.split(" to ");
 	// we expect only 2 languages, source and target
 	if (fromTo.length !== 2) return null;
@@ -86,10 +88,14 @@ export const TranslateResult: ResultSelector<TranslateResultNode> = (
 	const sourceLanguage = fromTo[0].trim();
 	const translationLanguage = fromTo[1].trim();
 	// source text is in the format "hello" in Japanese
-	const sourceTextBlock = $(TranslateSearchSelector.sourceText).text().trim();
+	const sourceTextBlock = translateBlock
+		.find(TranslateSearchSelector.sourceText)
+		.text()
+		.trim();
 	const sourceText = sourceTextBlock.match(TranslateSourceTextRegex)?.[1] ?? "";
 
-	const translatedText = $(TranslateSearchSelector.translatedText)
+	const translatedText = translateBlock
+		.find(TranslateSearchSelector.translatedText)
 		.text()
 		.trim();
 

--- a/packages/google-sr/src/results.ts
+++ b/packages/google-sr/src/results.ts
@@ -41,18 +41,16 @@ export const OrganicResult: ResultSelector<OrganicResultNode> = (
 	// parse each block individually for its content
 	// TODO: switched from cheerio.each to for..of loop (check performance in future tests)
 	for (const element of organicSearchBlocks) {
-		let link = $(element)
-			.find(OrganicSearchSelector.link)
-			.attr("href") as string;
+		let link = $(element).find(OrganicSearchSelector.link).attr("href") ?? null;
 		const description = $(element)
 			.find(OrganicSearchSelector.description)
 			.text() as string;
-		const title = $(element).find(OrganicSearchSelector.title).text();
-
-		if (typeof link === "string")
-			link = extractUrlFromGoogleLink(link) as string;
-
-		if (isEmpty(strictSelector, link, description, title)) continue;
+		const title = $(element).find(OrganicSearchSelector.title).text() as string;
+		link = extractUrlFromGoogleLink(link);
+		// if not links is found its not a valid result, we can safely skip it
+		if (typeof link !== "string") continue;
+		// both title and description can be empty, we skip the result only if strictSelector is true
+		if (isEmpty(strictSelector, description, title)) continue;
 
 		parsedResults.push({
 			type: ResultTypes.OrganicResult,

--- a/packages/google-sr/src/utils.ts
+++ b/packages/google-sr/src/utils.ts
@@ -9,7 +9,7 @@ const baseHeaders = {
 	"upgrade-insecure-requests": 1,
 	// the tested user agent is for Chrome 103 on Windows 10
 	"User-Agent":
-		"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/103.0.0.0 Safari/537.36",
+		"Links (2.29; Linux 6.11.0-13-generic x86_64; GNU C 13.2; text)",
 };
 
 /**
@@ -18,7 +18,10 @@ const baseHeaders = {
  * @returns
  * @private
  */
-export function extractUrlFromGoogleLink(googleLink: string): string | null {
+export function extractUrlFromGoogleLink(
+	googleLink: string | null,
+): string | null {
+	if (!googleLink) return null;
 	// Regular expression to extract the `q` or `imgurl` parameter from the link
 	const regex = /[?&](q|imgurl)=([^&]+)/;
 

--- a/packages/google-sr/tests/result.test.ts
+++ b/packages/google-sr/tests/result.test.ts
@@ -50,8 +50,7 @@ test("Search for translation results", async () => {
 		expect(result.sourceLanguage).to.be.a("string").and.not.empty;
 		expect(result.sourceText).to.be.a("string").and.not.empty;
 		expect(result.translationLanguage).to.be.a("string").and.not.empty;
-		expect(result.translationText).to.be.a("string").and.not.empty;
-		expect(result.translationPronunciation).to.be.a("string").and.not.empty;
+		expect(result.translatedText).to.be.a("string").and.not.empty;
 	}
 });
 

--- a/packages/google-sr/tests/result.test.ts
+++ b/packages/google-sr/tests/result.test.ts
@@ -67,26 +67,25 @@ test("Search for dictionary results", async () => {
 
 		expect(result.phonetic).to.be.a("string").and.not.empty;
 		expect(result.word).to.be.a("string").and.not.empty;
-		expect(result.audio).to.be.a("string").and.not.empty;
 		// we only expect 2 definitions for this query
-		expect(result.definitions).to.be.an("array").and.toHaveLength(2);
+		expect(result.meanings).to.be.an("array").and.toHaveLength(2);
 
-		for (const definition of result.definitions) {
-			expect(definition.partOfSpeech).to.be.a("string").and.not.empty;
+		for (const meaning of result.meanings) {
+			expect(meaning.partOfSpeech).to.be.a("string").and.not.empty;
 			// check if partOfSpeech is a valid part of speech
-			expect(definition.partOfSpeech).to.be.oneOf([
+			expect(meaning.partOfSpeech).to.be.oneOf([
 				// these are only the expected part of speeches for this test query
 				// mismatch might indicate a issue
 				"noun",
 				"verb",
 			]);
 
-			expect(definition.definition).to.be.a("string").and.not.empty;
-			expect(definition.example).to.be.a("string").and.not.empty;
-
-			expect(definition.synonyms)
-				.to.be.an("array")
-				.and.to.length.be.greaterThan(0);
+			expect(meaning.definitions).to.be.an("array").and.not.empty;
+			for (const definition of meaning.definitions) {
+				expect(definition.definition).to.be.a("string").and.not.empty;
+				expect(definition.example).to.be.a("string").and.not.empty;
+				expect(definition.synonyms).to.be.an("array");
+			}
 		}
 	}
 });
@@ -146,33 +145,4 @@ test("Search for Knowledge panel results", async () => {
 	const meta1 = result.metadata[0];
 	// validate 1st metadata, if 1st is correct, others should be correct too
 	expect(meta1.label).toBe("Release date");
-	expect(meta1.value).toBe("October 26, 2014 (USA)");
-
-	// validate images
-	for (const image of result.images) {
-		expect(image.source).to.be.a("string");
-		expect(image.url).to.be.a("string");
-		// validate urls
-		expect(image.url).to.match(/^https?:\/\//);
-		expect(image.source).to.match(/^https?:\/\//);
-	}
-
-	// validate catalog
-	for (const catalog of result.catalog) {
-		expect(catalog.title).to.be.a("string");
-		// validate each item in catalog
-		for (const item of catalog.items) {
-			expect(item.title).to.be.a("string");
-			expect(item.image).to.be.a("string");
-			expect(item.image).to.match(/^https?:\/\//);
-			expect(item.caption).to.be.a("string");
-		}
-	}
-
-	// validate 1st catalog
-	const catalog1 = result.catalog[0];
-	expect(catalog1.title).toBe("Cast");
-	const item1 = catalog1.items[0];
-	expect(item1.title).toBe("Matthew McConaughey");
-	expect(item1.caption).toBe("Cooper");
 });

--- a/packages/google-that/README.md
+++ b/packages/google-that/README.md
@@ -55,6 +55,12 @@ This is not sponsored, supported, or affiliated with Google.
 The source code within this repository is intended solely for **educational & research purposes**.
 The author (typicalninja) & contributors takes **NO** responsibility for any issues that arise from its use, such as IP blocking by Google. Your discretion in usage is advised.
 
+# Links
+
+- [GitHub Repository](https://github.com/typicalninja/google-sr)
+- [NPM Package](https://www.npmjs.com/package/google-that)
+- [Discord](https://discord.gg/ynwckXS9T2)
+
 # Related projects 🥂
 
 - [google-sr](https://g-sr.vercel.app/google/sr) - Core project used in google-that


### PR DESCRIPTION
In a recent Google update, the ability to access search result pages without enabling JavaScript was disabled. (See [#51](https://github.com/typicalninja/google-sr/issues/51) for more details.)

Using resources such as [this Hacker News thread](https://news.ycombinator.com/item?id=42743344), I implemented a workaround that bypasses the JavaScript requirement by utilizing an alternate page version served to specific user agents.

However, this alternate page lacks certain features available on the standard page, resulting in the removal of some properties. Please refer to the changelog for a detailed list of changes.

**Closes #51**