### PR TITLE
chore/add editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+# This file ync setting between different IDE
+# It is used so every dev will use same formatting style
+
+# Your IDE must enable support for `editorconfig`
+# - VS Code: download https://marketplace.visualstudio.com/items?itemName=EditorConfig.EditorConfig
+
+# Make indentation with tab in all files
+[*]
+indent_style = tab
+indent_size = 2


### PR DESCRIPTION
## Why?

I usually use space for indentation, and after saving a file all tabs are converted to space.  
This is bad.  

The project started with tab indentation, so we keep it.  


With this `.editorconfig` (added file) the indentation rules are rigid and all IDE should use them.

Check you IDE, because you maybe need to enable editor config support.  
In Vs Code, you must download this extension:
- https://marketplace.visualstudio.com/items?itemName=EditorConfig.EditorConfig