### PR TITLE
feat/add news selector

### DIFF
--- a/.changeset/legal-trams-sit.md
+++ b/.changeset/legal-trams-sit.md
@@ -1,0 +1,6 @@
+---
+"google-sr-selectors": minor
+"google-sr": minor
+---
+
+Add `NewsSelector` for Google News

--- a/packages/google-sr-selectors/src/index.ts
+++ b/packages/google-sr-selectors/src/index.ts
@@ -74,4 +74,4 @@ export const NewsSearchSelector = {
 	published_date: ".fYyStc.YVIcad",
 	description: ".qXLe6d.FrIlee .fYyStc:first-of-type",
 	source: ".qXLe6d.dXDvrc .fYyStc",
-}
+};

--- a/packages/google-sr-selectors/src/index.ts
+++ b/packages/google-sr-selectors/src/index.ts
@@ -67,3 +67,11 @@ export const KnowledgePanelSelector = {
 	metadataLabel: "span.FrIlee > span.fYyStc",
 	metadataValue: "span.F9iS2e",
 };
+
+export const NewsSearchSelector = {
+	title: ".CVA68e.qXLe6d.fuLhoc.ZWRArf",
+	link: "a",
+	published_date: ".fYyStc.YVIcad",
+	description: ".qXLe6d.FrIlee .fYyStc:first-of-type",
+	source: ".qXLe6d.dXDvrc .fYyStc",
+}

--- a/packages/google-sr/src/constants.ts
+++ b/packages/google-sr/src/constants.ts
@@ -9,6 +9,7 @@ export const ResultTypes = {
 	TimeResult: "TIME",
 	CurrencyResult: "CURRENCY",
 	KnowledgePanelResult: "KNOWLEDGE_PANEL",
+	NewsResult: "NEWS",
 } as const;
 
 // Specific result types returned by gsr
@@ -59,6 +60,13 @@ export type KnowledgePanelResultNode = ResultNodeTyper<
 	metadata: KnowledgePanelMetadata[];
 };
 
+export type NewsResultNode = ResultNodeTyper<
+	typeof ResultTypes.NewsResult,
+	"title" | "published_date" | "description" | "source"
+> & {
+	link: string;
+};
+
 // All possible result types as a union
 export type SearchResultNode =
 	| OrganicResultNode
@@ -66,7 +74,8 @@ export type SearchResultNode =
 	| DictionaryResultNode
 	| TimeResultNode
 	| CurrencyResultNode
-	| KnowledgePanelResultNode;
+	| KnowledgePanelResultNode
+	| NewsResultNode;
 
 export interface SearchResultNodeLike {
 	type: string;

--- a/packages/google-sr/src/results.ts
+++ b/packages/google-sr/src/results.ts
@@ -4,6 +4,7 @@ import {
 	DictionarySearchSelector,
 	GeneralSelector,
 	KnowledgePanelSelector,
+	NewsSearchSelector,
 	OrganicSearchSelector,
 	TimeSearchSelector,
 	TranslateSearchSelector,
@@ -15,6 +16,7 @@ import {
 	type DictionaryResultNode,
 	type KnowledgePanelMetadata,
 	type KnowledgePanelResultNode,
+	type NewsResultNode,
 	type OrganicResultNode,
 	type ResultSelector,
 	ResultTypes,
@@ -363,4 +365,54 @@ export const KnowledgePanelResult: ResultSelector<KnowledgePanelResultNode> = (
 	});
 
 	return knowledgePanel;
+};
+
+/**
+ * Parses news search results.
+ * @returns Array of NewsResultNode
+ */
+export const NewsResult: ResultSelector<NewsResultNode> = (
+	$,
+	strictSelector,
+) => {
+	if (!$) throwNoCheerioError("NewsResult");
+	const parsedResults: NewsResultNode[] = [];
+	const newsSearchBlocks = $(GeneralSelector.block).toArray();
+	// parse each block individually for its content
+	// TODO: switched from cheerio.each to for..of loop (check performance in future tests)
+	for (const element of newsSearchBlocks) {
+		const rawLink =
+			$(element).find(NewsSearchSelector.link).attr("href") ?? null;
+		// if not links is found it's not a valid result, we can safely skip it
+		// most likely the first result can be a special block
+		if (typeof rawLink !== "string") continue;
+		// input: /url?q=https://example.com/about/&sa=U&ved=2ahUKEwi3tJu44JKNAxWc3gIHHdgBDogQxfQBegQIBRAC&usg=AOvVaw0yniKHiOvXs1sdLqSWk5zO
+		// output: https://example.com/about/
+		const link = rawLink.slice(7).split("&sa=")[0];
+
+		const title = $(element).find(NewsSearchSelector.title).text();
+
+		const description =
+			$(element).find(NewsSearchSelector.description).text() ?? "";
+
+		const source = $(element).find(NewsSearchSelector.source).text() ?? "";
+
+		const published_date =
+			$(element).find(NewsSearchSelector.published_date).text() ?? "";
+
+		// both title, description, source and published_date can be empty, we skip the result only if strictSelector is true
+		if (isEmpty(strictSelector, title, source, description, published_date))
+			continue;
+
+		parsedResults.push({
+			type: ResultTypes.NewsResult,
+			link,
+			title,
+			description,
+			source,
+			published_date,
+		});
+	}
+
+	return parsedResults;
 };

--- a/packages/google-sr/tests/result.test.ts
+++ b/packages/google-sr/tests/result.test.ts
@@ -3,6 +3,7 @@ import {
 	CurrencyResult,
 	DictionaryResult,
 	KnowledgePanelResult,
+	NewsResult,
 	OrganicResult,
 	ResultTypes,
 	TimeResult,
@@ -145,4 +146,38 @@ test("Search for Knowledge panel results", async () => {
 	const meta1 = result.metadata[0];
 	// validate 1st metadata, if 1st is correct, others should be correct too
 	expect(meta1.label).toBe("Release date");
+});
+
+test("Search for news results", async () => {
+	const queryResult = await search({
+		query: "nodejs",
+		resultTypes: [NewsResult],
+		// on some platforms (i.e github actions) it returns some weird results that does not have a link/description/title
+		// so we set strictSelector to true to ignore those results
+		//TODO: recheck in future as the tests pass on local machines (tested on 2 different machines)
+		strictSelector: true,
+		requestConfig: {
+			params: {
+				// Country code
+				gl: "us",
+				// Language code
+				hl: "en",
+				// TBM param (typeof search: news/images/...)
+				tbm: "nws",
+			},
+		},
+	});
+	expect(queryResult).length.greaterThan(0);
+
+	// verify all results are OrganicResults
+	for (const result of queryResult) {
+		expect(result.type).toBe(ResultTypes.NewsResult);
+
+		// verify properties are present and not empty;
+		expect(result.link).to.be.a("string").and.not.empty;
+		expect(result.description).to.be.a("string").and.not.empty;
+		expect(result.title).to.be.a("string").and.not.empty;
+		expect(result.published_date).to.be.a("string").and.not.empty;
+		expect(result.source).to.be.a("string").and.not.empty;
+	}
 });


### PR DESCRIPTION
Fixes #64

## Done

- `google-sr-selector`: added `NewsSearchSelector`
- `google-sr`: added `NewsResultNode` ts type
    NOTE: i made `link: string` intstead of `link: string | null` because I removed result with no link, so link is always `string`
- `google-sr`: added `NewsResult` cheerio parser

## Future Work

- add JsDocs to remember user to add `requestConfig.params.tbm=nws`
