### PR TITLE
refactor: rename CurrencyResult to UnitConversionResult

### DIFF
--- a/.changeset/fast-moose-lay.md
+++ b/.changeset/fast-moose-lay.md
@@ -1,0 +1,34 @@
+---
+"google-sr-selectors": major
+"google-sr": major
+"google-that": minor
+---
+
+Rename CurrencyResult to UnitConversionResult
+
+## Breaking Changes
+
+- `CurrencyResult` selector renamed to `UnitConversionResult`
+- `CurrencyResultNode` interface renamed to `UnitConversionResultNode`
+- Result type constant `ResultTypes.CurrencyResult` renamed to `ResultTypes.UnitConversionResult`
+- The selector now handles all conversion queries (currency, units, measurements, etc.)
+
+The original `CurrencyResult` selector was found to work effectively for all types of conversion queries (currency, distance, weight, temperature, etc.), not just currency conversions. The rename better captures its actual functionality and makes the API more intuitive for users performing various conversion searches.
+
+```diff
+// Before
+- import { CurrencyResult, CurrencyResultNode } from 'google-sr';
++ import { UnitConversionResult, UnitConversionResultNode } from 'google-sr';
+import { ResultTypes } from 'google-sr';
+
+const results = search({
+  query: "100 USD to EUR",
+-  parsers: [CurrencyResult]
++  parsers: [UnitConversionResult]
+});
+
+- if (result.type === ResultTypes.CurrencyResult) {
++ if (result.type === ResultTypes.UnitConversionResult) {
+  // handle unit conversion result
+}
+```

--- a/apps/examples/src/kitchen-sink.ts
+++ b/apps/examples/src/kitchen-sink.ts
@@ -4,7 +4,6 @@
  */
 
 import {
-	CurrencyResult,
 	DictionaryResult,
 	KnowledgePanelResult,
 	NewsResult,
@@ -14,6 +13,7 @@ import {
 	ResultTypes,
 	TimeResult,
 	TranslateResult,
+	UnitConversionResult,
 	search,
 } from "google-sr";
 
@@ -26,7 +26,7 @@ const results = await search({
 	resultTypes: [
 		DictionaryResult,
 		TimeResult,
-		CurrencyResult,
+		UnitConversionResult,
 		TranslateResult,
 		OrganicResult,
 		KnowledgePanelResult,

--- a/packages/google-sr-selectors/src/index.ts
+++ b/packages/google-sr-selectors/src/index.ts
@@ -46,7 +46,7 @@ export const TimeSearchSelector = {
 	timeInWords: "div > span.qXLe6d.F9iS2e > span.fYyStc.YVIcad",
 };
 
-export const ConversionSelector = {
+export const UnitConversionSelector = {
 	from: "div > div.kk667b > span.F9iS2e > span.fYyStc.YVIcad",
 	to: "div > table.Mw6wOc > tbody > tr > td > div > div > span.qXLe6d.epoveb > span.fYyStc",
 };

--- a/packages/google-sr-selectors/src/index.ts
+++ b/packages/google-sr-selectors/src/index.ts
@@ -46,9 +46,9 @@ export const TimeSearchSelector = {
 	timeInWords: "div > span.qXLe6d.F9iS2e > span.fYyStc.YVIcad",
 };
 
-export const CurrencyConvertSelector = {
+export const ConversionSelector = {
 	from: "div > div.kk667b > span.F9iS2e > span.fYyStc.YVIcad",
-	to: "div > table.Mw6wOc > tbody > tr > td > div.fBgPuf > div > span.qXLe6d.epoveb > span.fYyStc",
+	to: "div > table.Mw6wOc > tbody > tr > td > div > div > span.qXLe6d.epoveb > span.fYyStc",
 };
 
 export const KnowledgePanelSelector = {

--- a/packages/google-sr/src/constants.ts
+++ b/packages/google-sr/src/constants.ts
@@ -1,12 +1,12 @@
 import type { CheerioAPI } from "cheerio";
 import type {
-	CurrencyResultNode,
 	DictionaryResultNode,
 	KnowledgePanelResultNode,
 	NewsResultNode,
 	OrganicResultNode,
 	TimeResultNode,
 	TranslateResultNode,
+	UnitConversionResultNode,
 } from "./results";
 
 export const ResultTypes = {
@@ -14,7 +14,7 @@ export const ResultTypes = {
 	TranslateResult: "TRANSLATE",
 	DictionaryResult: "DICTIONARY",
 	TimeResult: "TIME",
-	CurrencyResult: "CURRENCY",
+	UnitConversionResult: "CONVERSION",
 	KnowledgePanelResult: "KNOWLEDGE_PANEL",
 	NewsResult: "NEWS",
 } as const;
@@ -25,7 +25,7 @@ export type SearchResultNode =
 	| TranslateResultNode
 	| DictionaryResultNode
 	| TimeResultNode
-	| CurrencyResultNode
+	| UnitConversionResultNode
 	| KnowledgePanelResultNode
 	| NewsResultNode;
 

--- a/packages/google-sr/src/results/conversion.ts
+++ b/packages/google-sr/src/results/conversion.ts
@@ -6,10 +6,10 @@ import {
 import { isEmpty, throwNoCheerioError } from "../utils";
 
 // Importing the Selectors from google-sr-selectors
-import { ConversionSelector, GeneralSelector } from "google-sr-selectors";
+import { GeneralSelector, UnitConversionSelector } from "google-sr-selectors";
 
-export interface ConversionResultNode extends SearchResultNodeLike {
-	type: typeof ResultTypes.CurrencyResult;
+export interface UnitConversionResultNode extends SearchResultNodeLike {
+	type: typeof ResultTypes.UnitConversionResult;
 	from: string; // The currency being converted from
 	to: string; // The currency being converted to
 }
@@ -18,23 +18,23 @@ export interface ConversionResultNode extends SearchResultNodeLike {
  * Parses currency convert search results.
  * @returns Array of CurrencyResultNode
  */
-export const ConversionResult: ResultSelector<ConversionResultNode> = (
+export const UnitConversionResult: ResultSelector<UnitConversionResultNode> = (
 	$,
 	strictSelector,
 ) => {
-	if (!$) throwNoCheerioError("CurrencyResult");
+	if (!$) throwNoCheerioError("UnitConversionResult");
 	const block = $(GeneralSelector.block).first();
 	const from = block
-		.find(ConversionSelector.from)
+		.find(UnitConversionSelector.from)
 		.text()
 		.replace("=", "")
 		.trim();
-	const to = block.find(ConversionSelector.to).text().trim();
+	const to = block.find(UnitConversionSelector.to).text().trim();
 
 	if (isEmpty(strictSelector, from, to)) return null;
 
 	return {
-		type: ResultTypes.CurrencyResult,
+		type: ResultTypes.UnitConversionResult,
 		from: from,
 		to,
 	};

--- a/packages/google-sr/src/results/conversion.ts
+++ b/packages/google-sr/src/results/conversion.ts
@@ -10,13 +10,13 @@ import { GeneralSelector, UnitConversionSelector } from "google-sr-selectors";
 
 export interface UnitConversionResultNode extends SearchResultNodeLike {
 	type: typeof ResultTypes.UnitConversionResult;
-	from: string; // The currency being converted from
-	to: string; // The currency being converted to
+	from: string; // The conversion unit being converted from
+	to: string; // The conversion unit being converted to
 }
 
 /**
- * Parses currency convert search results.
- * @returns Array of CurrencyResultNode
+ * Parses unit conversion search results.
+ * @returns Array of UnitConversionResultNode
  */
 export const UnitConversionResult: ResultSelector<UnitConversionResultNode> = (
 	$,

--- a/packages/google-sr/src/results/conversion.ts
+++ b/packages/google-sr/src/results/conversion.ts
@@ -6,9 +6,9 @@ import {
 import { isEmpty, throwNoCheerioError } from "../utils";
 
 // Importing the Selectors from google-sr-selectors
-import { CurrencyConvertSelector, GeneralSelector } from "google-sr-selectors";
+import { ConversionSelector, GeneralSelector } from "google-sr-selectors";
 
-export interface CurrencyResultNode extends SearchResultNodeLike {
+export interface ConversionResultNode extends SearchResultNodeLike {
 	type: typeof ResultTypes.CurrencyResult;
 	from: string; // The currency being converted from
 	to: string; // The currency being converted to
@@ -18,18 +18,19 @@ export interface CurrencyResultNode extends SearchResultNodeLike {
  * Parses currency convert search results.
  * @returns Array of CurrencyResultNode
  */
-export const CurrencyResult: ResultSelector<CurrencyResultNode> = (
+export const ConversionResult: ResultSelector<ConversionResultNode> = (
 	$,
 	strictSelector,
 ) => {
 	if (!$) throwNoCheerioError("CurrencyResult");
 	const block = $(GeneralSelector.block).first();
 	const from = block
-		.find(CurrencyConvertSelector.from)
+		.find(ConversionSelector.from)
 		.text()
 		.replace("=", "")
 		.trim();
-	const to = block.find(CurrencyConvertSelector.to).text().trim();
+	const to = block.find(ConversionSelector.to).text().trim();
+
 	if (isEmpty(strictSelector, from, to)) return null;
 
 	return {

--- a/packages/google-sr/src/results/index.ts
+++ b/packages/google-sr/src/results/index.ts
@@ -2,6 +2,6 @@ export * from "./organic";
 export * from "./translate";
 export * from "./dictionary";
 export * from "./time";
-export * from "./currency";
+export * from "./conversion";
 export * from "./knowledge-panel";
 export * from "./news";

--- a/packages/google-sr/tests/results.test.ts
+++ b/packages/google-sr/tests/results.test.ts
@@ -1,7 +1,6 @@
 import isCi from "is-ci";
 import { afterEach, describe, it } from "vitest";
 import {
-	CurrencyResult,
 	DictionaryResult,
 	KnowledgePanelResult,
 	NewsResult,
@@ -9,6 +8,7 @@ import {
 	ResultTypes,
 	TimeResult,
 	TranslateResult,
+	UnitConversionResult,
 	search,
 } from "../src";
 
@@ -112,14 +112,14 @@ describe(
 		it("Search for currency results", async ({ expect }) => {
 			const results = await search({
 				query: "100 USD to EUR",
-				resultTypes: [CurrencyResult],
+				resultTypes: [UnitConversionResult],
 				...GLOBAL_SEARCH_OPTIONS,
 			});
 
 			// Expect only one result
 			expect(results).to.be.an("array").and.have.lengthOf(1);
 			const res = results[0];
-			expect(res.type).toBe(ResultTypes.CurrencyResult);
+			expect(res.type).toBe(ResultTypes.UnitConversionResult);
 			expect(res.from).to.be.a("string").and.equal("100 United States Dollar");
 			// unless we have some magic power to predict the future, the value will change
 			// so just check it at least contains "Euro"

--- a/packages/google-sr/tests/results.test.ts
+++ b/packages/google-sr/tests/results.test.ts
@@ -109,7 +109,7 @@ describe(
 			}
 		});
 
-		it("Search for currency results", async ({ expect }) => {
+		it("Search for unit conversion results", async ({ expect }) => {
 			const results = await search({
 				query: "100 USD to EUR",
 				resultTypes: [UnitConversionResult],

--- a/packages/google-that/src/constants.ts
+++ b/packages/google-that/src/constants.ts
@@ -12,7 +12,7 @@ export interface CLIArguments {
 
 export const resultTypeArray: CLIArguments["resultTypes"] = [
 	ResultTypes.OrganicResult,
-	ResultTypes.CurrencyResult,
+	ResultTypes.UnitConversionResult,
 	ResultTypes.DictionaryResult,
 	ResultTypes.TimeResult,
 	ResultTypes.TranslateResult,

--- a/packages/google-that/src/helpers.ts
+++ b/packages/google-that/src/helpers.ts
@@ -1,5 +1,4 @@
 import {
-	CurrencyResult,
 	DictionaryResult,
 	KnowledgePanelResult,
 	OrganicResult,
@@ -7,6 +6,7 @@ import {
 	ResultTypes,
 	TimeResult,
 	TranslateResult,
+	UnitConversionResult,
 } from "google-sr";
 import type { CLIArguments } from "./constants.js";
 
@@ -41,8 +41,8 @@ export function selectorTypeToSelector(selector: string): ResultSelector {
 			return TranslateResult;
 		case ResultTypes.DictionaryResult:
 			return DictionaryResult;
-		case ResultTypes.CurrencyResult:
-			return CurrencyResult;
+		case ResultTypes.UnitConversionResult:
+			return UnitConversionResult;
 		case ResultTypes.KnowledgePanelResult:
 			return KnowledgePanelResult;
 		default:


### PR DESCRIPTION
The original `CurrencyResult` selector was found to work effectively for all types of conversion queries (currency, distance, weight, temperature, etc.), not just currency conversions. The rename better captures its actual functionality and makes the API more intuitive for users performing various conversion searches.
