### PR TITLE
refactor: deprecate strictSelector in favor of noPartialResults

### DIFF
--- a/.changeset/old-pugs-hunt.md
+++ b/.changeset/old-pugs-hunt.md
@@ -1,0 +1,14 @@
+---
+"google-sr": major
+---
+
+Deprecate strictSelector in favor of noPartialResults
+
+The `strictSelector` option has been deprecated and replaced with `noPartialResults` for improved clarity. The new option name accurately describes its behavior.
+
+```diff
+search({
+- strictSelector: true,
++ noPartialResults: true,
+});
+```

--- a/packages/google-sr/src/constants.ts
+++ b/packages/google-sr/src/constants.ts
@@ -40,12 +40,15 @@ export interface SearchResultNodeLike {
 // the type used to identify a parser/selector function
 export type ResultSelector<
 	R extends SearchResultNodeLike = SearchResultNodeLike,
-> = (cheerio: CheerioAPI, strictSelector: boolean) => R[] | R | null;
+> = (cheerio: CheerioAPI, noPartialResults: boolean) => R[] | R | null;
 
 /**
  * Search options for single page search
  */
-export interface SearchOptions<R extends ResultSelector = ResultSelector> {
+export interface SearchOptions<
+	R extends ResultSelector = ResultSelector,
+	N extends boolean = false,
+> {
 	/**
 	 * Search query
 	 */
@@ -56,9 +59,15 @@ export interface SearchOptions<R extends ResultSelector = ResultSelector> {
 	resultTypes?: R[];
 
 	/**
-	 * when true, will only return resultNodes that do not contain any undefined/empty properties
+	 * @deprecated Use `noPartialResults` instead. Will be removed in a future version.
 	 */
-	strictSelector?: boolean;
+	strictSelector?: N;
+
+	/**
+	 * When true, excludes results that have undefined or empty properties.
+	 * @default false - Partial results are included.
+	 */
+	noPartialResults?: N;
 
 	/**
 	 * Custom request configuration to be sent with the request
@@ -71,7 +80,8 @@ export interface SearchOptions<R extends ResultSelector = ResultSelector> {
  */
 export interface SearchOptionsWithPages<
 	R extends ResultSelector = ResultSelector,
-> extends SearchOptions<R> {
+	N extends boolean = false,
+> extends SearchOptions<R, N> {
 	/**
 	 * Total number of pages to search or an array of specific pages to search
 	 *

--- a/packages/google-sr/src/results/conversion.ts
+++ b/packages/google-sr/src/results/conversion.ts
@@ -20,7 +20,7 @@ export interface UnitConversionResultNode extends SearchResultNodeLike {
  */
 export const UnitConversionResult: ResultSelector<UnitConversionResultNode> = (
 	$,
-	strictSelector,
+	noPartialResults,
 ) => {
 	if (!$) throwNoCheerioError("UnitConversionResult");
 	const block = $(GeneralSelector.block).first();
@@ -31,7 +31,7 @@ export const UnitConversionResult: ResultSelector<UnitConversionResultNode> = (
 		.trim();
 	const to = block.find(UnitConversionSelector.to).text().trim();
 
-	if (isEmpty(strictSelector, from, to)) return null;
+	if (isEmpty(noPartialResults, from, to)) return null;
 
 	return {
 		type: ResultTypes.UnitConversionResult,

--- a/packages/google-sr/src/results/dictionary.ts
+++ b/packages/google-sr/src/results/dictionary.ts
@@ -60,7 +60,7 @@ const parseDefinitionBlock = (
  */
 export const DictionaryResult: ResultSelector<DictionaryResultNode> = (
 	$,
-	strictSelector,
+	noPartialResults,
 ) => {
 	if (!$) throwNoCheerioError("DictionaryResult");
 	const dictionaryBlock = $(GeneralSelector.block).first();
@@ -128,7 +128,7 @@ export const DictionaryResult: ResultSelector<DictionaryResultNode> = (
 		}
 	}
 
-	if (isEmpty(strictSelector, phonetic, word)) return null;
+	if (isEmpty(noPartialResults, phonetic, word)) return null;
 
 	return {
 		type: ResultTypes.DictionaryResult,

--- a/packages/google-sr/src/results/knowledge-panel.ts
+++ b/packages/google-sr/src/results/knowledge-panel.ts
@@ -30,12 +30,12 @@ export interface KnowledgePanelResultNode extends SearchResultNodeLike {
 /**
  * Parses knowledge panel search results.
  * @param $
- * @param strictSelector
+ * @param noPartialResults
  * @returns KnowledgePanelResultNode
  */
 export const KnowledgePanelResult: ResultSelector<KnowledgePanelResultNode> = (
 	$,
-	strictSelector,
+	noPartialResults,
 ) => {
 	if (!$) throwNoCheerioError("KnowledgePanelResult");
 	// knowledge panel can be anywhere, at the start, or +x (mostly 2) from the start
@@ -92,7 +92,7 @@ export const KnowledgePanelResult: ResultSelector<KnowledgePanelResultNode> = (
 			});
 		}
 
-		if (!isEmpty(strictSelector, title, description, label))
+		if (!isEmpty(noPartialResults, title, description, label))
 			knowledgePanel = {
 				type: ResultTypes.KnowledgePanelResult,
 				title,

--- a/packages/google-sr/src/results/news.ts
+++ b/packages/google-sr/src/results/news.ts
@@ -46,7 +46,7 @@ export interface NewsResultNode extends SearchResultNodeLike {
  */
 export const NewsResult: ResultSelector<NewsResultNode> = (
 	$,
-	strictSelector,
+	noPartialResults,
 ) => {
 	if (!$) throwNoCheerioError("NewsResult");
 	const parsedResults: NewsResultNode[] = [];
@@ -71,7 +71,7 @@ export const NewsResult: ResultSelector<NewsResultNode> = (
 			$(element).find(NewsSearchSelector.published_date).text() ?? "";
 
 		// both title, description, source and published_date can be empty, we skip the result only if strictSelector is true
-		if (isEmpty(strictSelector, title, source, description, published_date))
+		if (isEmpty(noPartialResults, title, source, description, published_date))
 			continue;
 
 		parsedResults.push({

--- a/packages/google-sr/src/results/organic.ts
+++ b/packages/google-sr/src/results/organic.ts
@@ -25,7 +25,7 @@ export interface OrganicResultNode extends SearchResultNodeLike {
  */
 export const OrganicResult: ResultSelector<OrganicResultNode> = (
 	$,
-	strictSelector,
+	noPartialResults,
 ) => {
 	// Check if the user has called the function directly
 	// Most likely, they have passed the result of calling the function instead of the function itself
@@ -45,7 +45,7 @@ export const OrganicResult: ResultSelector<OrganicResultNode> = (
 		// most likely the first result can be a special block
 		if (typeof link !== "string") continue;
 		// both title and description can be empty, we skip the result only if strictSelector is true
-		if (isEmpty(strictSelector, description, title)) continue;
+		if (isEmpty(noPartialResults, description, title)) continue;
 
 		parsedResults.push({
 			type: ResultTypes.OrganicResult,

--- a/packages/google-sr/src/results/time.ts
+++ b/packages/google-sr/src/results/time.ts
@@ -21,7 +21,7 @@ export interface TimeResultNode extends SearchResultNodeLike {
  */
 export const TimeResult: ResultSelector<TimeResultNode> = (
 	$,
-	strictSelector,
+	noPartialResults,
 ) => {
 	if (!$) throwNoCheerioError("TimeResult");
 	const block = $(TimeSearchSelector.block).first();
@@ -32,7 +32,7 @@ export const TimeResult: ResultSelector<TimeResultNode> = (
 	if (!layoutTable) return null;
 	const time = layoutTable.find(TimeSearchSelector.time).text();
 	const timeInWords = layoutTable.find(TimeSearchSelector.timeInWords).text();
-	if (isEmpty(strictSelector, time, timeInWords)) return null;
+	if (isEmpty(noPartialResults, time, timeInWords)) return null;
 
 	return {
 		type: ResultTypes.TimeResult,

--- a/packages/google-sr/src/results/translate.ts
+++ b/packages/google-sr/src/results/translate.ts
@@ -23,7 +23,7 @@ export interface TranslateResultNode extends SearchResultNodeLike {
  */
 export const TranslateResult: ResultSelector<TranslateResultNode> = (
 	$,
-	strictSelector,
+	noPartialResults,
 ) => {
 	if (!$) throwNoCheerioError("TranslateResult");
 	// only one block is expected, and it should be the first one
@@ -54,7 +54,7 @@ export const TranslateResult: ResultSelector<TranslateResultNode> = (
 
 	if (
 		isEmpty(
-			strictSelector,
+			noPartialResults,
 			sourceLanguage,
 			translationLanguage,
 			sourceText,

--- a/packages/google-sr/src/search.ts
+++ b/packages/google-sr/src/search.ts
@@ -18,14 +18,15 @@ import {
  * @returns Search results as an array of SearchResultNodes
  */
 export async function search<R extends ResultSelector = typeof OrganicResult>(
-	options: SearchOptions<R> & { strictSelector?: false },
+	options: SearchOptions<R, false>,
 ): Promise<SearchResultTypeFromSelector<R>[]>;
 export async function search<R extends ResultSelector = typeof OrganicResult>(
-	options: SearchOptions<R> & { strictSelector: true },
+	options: SearchOptions<R, true>,
 ): Promise<SearchResultTypeFromSelector<R, true>[]>;
-export async function search<R extends ResultSelector = typeof OrganicResult>(
-	options: SearchOptions<R>,
-) {
+export async function search<
+	R extends ResultSelector = typeof OrganicResult,
+	N extends boolean = false,
+>(options: SearchOptions<R, N>) {
 	if (!options)
 		throw new TypeError(
 			`Search options must be provided. Received ${typeof options}`,
@@ -41,9 +42,13 @@ export async function search<R extends ResultSelector = typeof OrganicResult>(
 	let searchResults: SearchResultTypeFromSelector<R>[] = [];
 	// Iterate over each selector to call it with the cheerioApi and concatenate the results
 	for (const selector of selectors) {
+		// handle deprecated strictSelector option in the same way as noPartialResults
+		// noPartialResults takes precedence over strictSelector if both are provided
+		const noPartialResults =
+			options.noPartialResults ?? options.strictSelector ?? false;
 		const result = selector(
 			cheerioApi,
-			Boolean(options.strictSelector),
+			noPartialResults,
 		) as SearchResultTypeFromSelector<R>[];
 		// Result must be flattened to a single array
 		if (result) searchResults = searchResults.concat(result);
@@ -84,16 +89,17 @@ export async function search<R extends ResultSelector = typeof OrganicResult>(
 export async function searchWithPages<
 	R extends ResultSelector = typeof OrganicResult,
 >(
-	options: SearchOptionsWithPages<R> & { strictSelector?: false },
+	options: SearchOptionsWithPages<R, false>,
 ): Promise<SearchResultTypeFromSelector<R>[][]>;
 export async function searchWithPages<
 	R extends ResultSelector = typeof OrganicResult,
 >(
-	options: SearchOptionsWithPages<R> & { strictSelector: true },
+	options: SearchOptionsWithPages<R, true>,
 ): Promise<SearchResultTypeFromSelector<R, true>[][]>;
 export async function searchWithPages<
 	R extends ResultSelector = typeof OrganicResult,
->(options: SearchOptionsWithPages<R>) {
+	N extends boolean = false,
+>(options: SearchOptionsWithPages<R, N>) {
 	if (!options)
 		throw new TypeError(
 			`Search options must be provided. Received ${typeof options}`,

--- a/packages/google-sr/src/search.ts
+++ b/packages/google-sr/src/search.ts
@@ -41,11 +41,16 @@ export async function search<
 	const selectors = options.resultTypes || [OrganicResult];
 	let searchResults: SearchResultTypeFromSelector<R>[] = [];
 	// Iterate over each selector to call it with the cheerioApi and concatenate the results
+	// handle deprecated strictSelector option in the same way as noPartialResults
+	// noPartialResults takes precedence over strictSelector if both are provided
+	const noPartialResults =
+		options.noPartialResults ?? options.strictSelector ?? false;
+	if (typeof options.strictSelector !== "undefined") {
+		console.warn(
+			`The 'strictSelector' option is deprecated and will be removed in a future version. Use 'noPartialResults' instead.`,
+		);
+	}
 	for (const selector of selectors) {
-		// handle deprecated strictSelector option in the same way as noPartialResults
-		// noPartialResults takes precedence over strictSelector if both are provided
-		const noPartialResults =
-			options.noPartialResults ?? options.strictSelector ?? false;
 		const result = selector(
 			cheerioApi,
 			noPartialResults,

--- a/packages/google-sr/src/utils.ts
+++ b/packages/google-sr/src/utils.ts
@@ -91,7 +91,10 @@ export function extractUrlFromGoogleLink(
  * @param opts
  * @returns
  */
-export function prepareRequestConfig(opts: SearchOptions): RequestOptions {
+export function prepareRequestConfig<
+	R extends ResultSelector,
+	N extends boolean,
+>(opts: SearchOptions<R, N>): RequestOptions {
 	if (typeof opts.query !== "string")
 		throw new TypeError(
 			`Search query must be a string, received ${typeof opts.query} instead.`,


### PR DESCRIPTION
The `strictSelector` option has been deprecated and replaced with `noPartialResults` for improved clarity. The new option name accurately describes its behavior.
