### PR TITLE
refactor: skip parsing when data is empty and partial results are disabled

### DIFF
--- a/.changeset/cuddly-bars-do.md
+++ b/.changeset/cuddly-bars-do.md
@@ -1,0 +1,5 @@
+---
+"google-sr": patch
+---
+
+Optimize parser performance by checking for empty data earlier when noPartialResults is enabled

--- a/packages/google-sr/src/results/conversion.ts
+++ b/packages/google-sr/src/results/conversion.ts
@@ -5,7 +5,7 @@ import {
 	ResultTypes,
 	type SearchResultNodeLike,
 } from "../constants";
-import { isEmpty, throwNoCheerioError } from "../utils";
+import { isStringEmpty, throwNoCheerioError } from "../utils";
 
 export interface UnitConversionResultNode extends SearchResultNodeLike {
 	type: typeof ResultTypes.UnitConversionResult;
@@ -28,9 +28,12 @@ export const UnitConversionResult: ResultSelector<UnitConversionResultNode> = (
 		.text()
 		.replace("=", "")
 		.trim();
+
+	if (noPartialResults && isStringEmpty(from)) return null;
+
 	const to = block.find(UnitConversionSelector.to).text().trim();
 
-	if (isEmpty(noPartialResults, from, to)) return null;
+	if (noPartialResults && isStringEmpty(to)) return null;
 
 	return {
 		type: ResultTypes.UnitConversionResult,

--- a/packages/google-sr/src/results/dictionary.ts
+++ b/packages/google-sr/src/results/dictionary.ts
@@ -6,7 +6,7 @@ import {
 	ResultTypes,
 	type SearchResultNodeLike,
 } from "../constants";
-import { isEmpty, throwNoCheerioError } from "../utils";
+import { isStringEmpty, throwNoCheerioError } from "../utils";
 
 export interface DictionaryDefinition {
 	definition: string; // The definition text
@@ -63,23 +63,28 @@ export const DictionaryResult: ResultSelector<DictionaryResultNode> = (
 ) => {
 	if (!$) throwNoCheerioError("DictionaryResult");
 	const dictionaryBlock = $(GeneralSelector.block).first();
-	if (!dictionaryBlock) return null;
+	if (!dictionaryBlock.length) return null;
 	const phonetic = dictionaryBlock
 		.find(DictionarySearchSelector.phonetic)
 		.first()
 		.text()
 		.trim();
+
+	if (noPartialResults && isStringEmpty(phonetic)) return null;
+
 	const word = dictionaryBlock
 		.find(DictionarySearchSelector.word)
 		.text()
 		.trim();
+
+	if (noPartialResults && isStringEmpty(word)) return null;
 
 	const meanings: DictionaryMeaning[] = [];
 	const definitionContainer = dictionaryBlock
 		.find(DictionarySearchSelector.definitionsContainer)
 		.first();
 	// if no definitions, we return null
-	if (!definitionContainer) return null;
+	if (!definitionContainer.length) return null;
 	const definitionBlocks = definitionContainer
 		.find(DictionarySearchSelector.definitionsBlock)
 		.toArray();
@@ -92,7 +97,7 @@ export const DictionaryResult: ResultSelector<DictionaryResultNode> = (
 		if (!partOfSpeech) {
 			// if no previous part of speech, then we expect this block to have it
 			// normally the first (and only) element in this block is the part of speech
-			// but just to be sure we use first() to get the first element with a selector
+			// but just to be sure we use first() to get the first element with the selector
 			partOfSpeech = $(definitionBlock)
 				.find(DictionarySearchSelector.definitionPartOfSpeech)
 				.first()
@@ -126,8 +131,6 @@ export const DictionaryResult: ResultSelector<DictionaryResultNode> = (
 			partOfSpeech = null;
 		}
 	}
-
-	if (isEmpty(noPartialResults, phonetic, word)) return null;
 
 	return {
 		type: ResultTypes.DictionaryResult,

--- a/packages/google-sr/src/results/news.ts
+++ b/packages/google-sr/src/results/news.ts
@@ -7,7 +7,7 @@ import {
 } from "../constants";
 import {
 	extractUrlFromGoogleLink,
-	isEmpty,
+	isStringEmpty,
 	throwNoCheerioError,
 } from "../utils";
 
@@ -55,23 +55,19 @@ export const NewsResult: ResultSelector<NewsResultNode> = (
 		const rawLink =
 			$(element).find(NewsSearchSelector.link).attr("href") ?? null;
 		// if not links is found it's not a valid result, we can safely skip it
-		// most likely the first result can be a special block
 		if (typeof rawLink !== "string") continue;
 		const link = extractUrlFromGoogleLink(rawLink) ?? "";
-
+		if (noPartialResults && isStringEmpty(link)) continue;
 		const title = $(element).find(NewsSearchSelector.title).text();
-
-		const description =
-			$(element).find(NewsSearchSelector.description).text() ?? "";
-
+		if (noPartialResults && isStringEmpty(title)) continue;
+		const description = $(element).find(NewsSearchSelector.description).text();
+		if (noPartialResults && isStringEmpty(description)) continue;
 		const source = $(element).find(NewsSearchSelector.source).text() ?? "";
-
+		if (noPartialResults && isStringEmpty(source)) continue;
 		const published_date =
 			$(element).find(NewsSearchSelector.published_date).text() ?? "";
 
-		// both title, description, source and published_date can be empty, we skip the result only if noPartialResults is true
-		if (isEmpty(noPartialResults, title, source, description, published_date))
-			continue;
+		if (noPartialResults && isStringEmpty(published_date)) continue;
 
 		parsedResults.push({
 			type: ResultTypes.NewsResult,

--- a/packages/google-sr/src/results/organic.ts
+++ b/packages/google-sr/src/results/organic.ts
@@ -7,7 +7,7 @@ import {
 } from "../constants";
 import {
 	extractUrlFromGoogleLink,
-	isEmpty,
+	isStringEmpty,
 	throwNoCheerioError,
 } from "../utils";
 
@@ -31,20 +31,22 @@ export const OrganicResult: ResultSelector<OrganicResultNode> = (
 	if (!$) throwNoCheerioError("OrganicResult");
 
 	const parsedResults: OrganicResultNode[] = [];
-	const organicSearchBlocks = $(GeneralSelector.block).toArray();
+	const organicSearchBlocks = $(GeneralSelector.block).get();
 
 	for (const element of organicSearchBlocks) {
-		let link = $(element).find(OrganicSearchSelector.link).attr("href") ?? null;
 		const description = $(element)
 			.find(OrganicSearchSelector.description)
-			.text() as string;
-		const title = $(element).find(OrganicSearchSelector.title).text() as string;
+			.text();
+		if (noPartialResults && isStringEmpty(description)) continue;
+		const title = $(element).find(OrganicSearchSelector.title).text();
+		if (noPartialResults && isStringEmpty(title)) continue;
+
+		let link = $(element).find(OrganicSearchSelector.link).attr("href") ?? null;
+		if (noPartialResults && isStringEmpty(link)) continue;
 		link = extractUrlFromGoogleLink(link);
 		// if not links is found it's not a valid result, we can safely skip it
 		// most likely the first result can be a special block
 		if (typeof link !== "string") continue;
-		// both title and description can be empty, we skip the result only if noPartialResults is true
-		if (isEmpty(noPartialResults, description, title)) continue;
 
 		parsedResults.push({
 			type: ResultTypes.OrganicResult,

--- a/packages/google-sr/src/results/time.ts
+++ b/packages/google-sr/src/results/time.ts
@@ -5,7 +5,7 @@ import {
 	ResultTypes,
 	type SearchResultNodeLike,
 } from "../constants";
-import { isEmpty, throwNoCheerioError } from "../utils";
+import { isStringEmpty, throwNoCheerioError } from "../utils";
 
 export interface TimeResultNode extends SearchResultNodeLike {
 	type: typeof ResultTypes.TimeResult;
@@ -26,12 +26,15 @@ export const TimeResult: ResultSelector<TimeResultNode> = (
 	const block = $(TimeSearchSelector.block).first();
 	const location = block.find(TimeSearchSelector.location).text();
 	// if we don't find a valid location drop this
-	if (location === "") return null;
+	if (noPartialResults && isStringEmpty(location)) return null;
 	const layoutTable = block.find(TimeSearchSelector.timeLayoutTable).first();
 	if (!layoutTable) return null;
 	const time = layoutTable.find(TimeSearchSelector.time).text();
+	// if we don't find a valid time drop this
+	if (noPartialResults && isStringEmpty(time)) return null;
 	const timeInWords = layoutTable.find(TimeSearchSelector.timeInWords).text();
-	if (isEmpty(noPartialResults, time, timeInWords)) return null;
+	// if we don't find a valid time in words drop this
+	if (noPartialResults && isStringEmpty(timeInWords)) return null;
 
 	return {
 		type: ResultTypes.TimeResult,

--- a/packages/google-sr/src/utils.ts
+++ b/packages/google-sr/src/utils.ts
@@ -136,23 +136,17 @@ export function throwNoCheerioError(
 }
 
 /**
- * Internal utility function to check if all properties are empty,
- *  with additional logic for noPartialResults option to check if any property is empty
- * @param result
- * @param noPartialResults
+ * Internal utility function to check if a value is empty.
+ * It checks for:
+ * - Empty strings
+ * - Undefined or null values
+ * @param value The value to check for emptiness
  * @private
  */
-export function isEmpty(
-	noPartialResults: boolean,
-	...values: (string | undefined | null)[]
-): boolean {
-	if (noPartialResults)
-		return values.some(
-			(value) => value === "" || value === undefined || value === null,
-		);
-	return values.every(
-		(value) => value === "" || value === undefined || value === null,
-	);
+export function isStringEmpty(value: unknown): boolean {
+	if (typeof value !== "string") return true;
+	if (value === "" || value === undefined || value === null) return true;
+	return false;
 }
 
 /**


### PR DESCRIPTION
Currently, the parser processes all values before checking if they are empty at the end of the parsing cycle. This approach wastes computational resources when `noPartialResults` is enabled, as the parser continues processing even when it encounters empty data that will ultimately be rejected.

This change moves the validation check to occur immediately after parsing the DOM node. If the data is empty and `noPartialResults` is enabled, the parser now returns null early in the process.