### PR TITLE
fix: validation error when requestConfig is undefined / null

### DIFF
--- a/packages/google-sr/src/utils.ts
+++ b/packages/google-sr/src/utils.ts
@@ -99,7 +99,7 @@ export function prepareRequestConfig<
 		throw new TypeError(
 			`Search query must be a string, received ${typeof opts.query} instead.`,
 		);
-	if (typeof opts.requestConfig !== "object")
+	if (opts.requestConfig && typeof opts.requestConfig !== "object")
 		throw new TypeError(
 			`Request config must be an object if specified, received ${typeof opts.requestConfig}.`,
 		);


### PR DESCRIPTION
A bug was introduced in #75 where `prepareRequestConfig` would attempt to validate `requestConfig` options even when the parameter was not provided, causing validation to fail on undefined values.

This broke the following usage pattern:

```ts
search({
  query: "Some query"
  // requestConfig omitted - should be valid but was throwing validation error
})
```

Added an existence check for `requestConfig` before running validation to ensure it only validates when the parameter is explicitly provided.