### PR TITLE
docs: add cjs deprecation notice to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,3 @@
-[npm-gsr]: https://www.npmjs.com/package/google-sr
-[stargazers]: https://github.com/typicalninja/google-sr/stargazers
-[discord]: https://discord.gg/ynwckXS9T2
-[test-action]: https://github.com/typicalninja/google-sr/actions/workflows/tests.yml
-[api-docs]: https://typicalninja.github.io/google-sr/
-[codefactor]: https://www.codefactor.io/repository/github/typicalninja/google-sr
-[codeberg]: https://codeberg.org/typicalninja/google-sr
-
 <h1 align="center">google-sr</h1>
 
 <p align="center">Scrape Google search results using JavaScript / TypeScript</p>
@@ -35,6 +27,8 @@
 # Install
 
 > Not supported in browser environments.
+
+> If you are using CommonJS, please read the [important notice](#notice-for-commonjs-users) about future ESM-only support.
 
 ```bash
 npm install google-sr
@@ -83,6 +77,23 @@ console.log(results); // see below
 
 > Additional examples can be found in [apps/examples](https://github.com/typicalninja/google-sr/tree/master/apps/examples) directory
 
+# Notice for CommonJS users
+
+This package currently includes both [CommonJS (CJS)][cjs-nodejs-docs] and [ES Modules (ESM)][esm-nodejs-docs] builds.
+
+Starting with **v7.x** (subject to change), we plan to drop CJS support and publish only ESM-only builds.
+
+#### Why ESM-only going forward?
+- **Modern JavaScript**: ESM is now the standard, offering better support for tree-shaking and static analysis.
+- **Reduces package size**: Maintaining a single build reduces package size and build complexity.
+- [Node.js `v20`+ supports require() on ESM modules natively][nodejs-v20-backport-note] (no flags needed)
+
+While Node.js v20 already supports ESM well, we will wait until its End-of-Life before removing CJS to give users and tooling more time to transition.
+
+> Note: This applies only to Node.js users, other runtimes like Bun and Deno already support ESM natively
+
+See this [gist for future migration tips][esm-migration-pure-esm-gist] and our [GitHub discussion][cjs-build-notice-discussion] for more details.
+
 # Tests
 
 Tests are written using [vitest](https://vitest.dev/) and can be run by using the `test` script.
@@ -106,3 +117,19 @@ This repository and the code inside it is licensed under the Apache-2.0 License.
 ---
 
 Want to support the project? [Star it on GitHub ★][stargazers]
+
+
+
+[npm-gsr]: https://www.npmjs.com/package/google-sr
+[stargazers]: https://github.com/typicalninja/google-sr/stargazers
+[discord]: https://discord.gg/ynwckXS9T2
+[test-action]: https://github.com/typicalninja/google-sr/actions/workflows/tests.yml
+[api-docs]: https://typicalninja.github.io/google-sr/
+[codefactor]: https://www.codefactor.io/repository/github/typicalninja/google-sr
+[codeberg]: https://codeberg.org/typicalninja/google-sr
+
+[nodejs-v20-backport-note]:https://nodejs.org/en/blog/release/v20.19.0/
+[esm-nodejs-docs]: https://nodejs.org/api/esm.html#introduction
+[cjs-nodejs-docs]: https://nodejs.org/api/modules.html#modules-commonjs-modules
+[cjs-build-notice-discussion]: https://github.com/typicalninja/google-sr/discussions/86
+[esm-migration-pure-esm-gist]: https://gist.github.com/sindresorhus/a39789f98801d908bbc7ff3ecc99d99c

--- a/packages/google-sr-selectors/README.md
+++ b/packages/google-sr-selectors/README.md
@@ -1,13 +1,4 @@
-[npm]: https://www.npmjs.com/package/google-sr-selectors
-[github-gsr]: https://github.com/typicalninja/google-sr/tree/master/packages/google-sr
-[github-gt]: https://github.com/typicalninja/google-sr/tree/master/packages/google-that
-[stargazers]: https://github.com/typicalninja/google-sr/stargazers
-[discord]: https://discord.gg/ynwckXS9T2
-[test-action]: https://github.com/typicalninja/google-sr/actions/workflows/tests.yml
-[api-docs]: https://typicalninja.github.io/google-sr/modules/google-sr-selectors_src.html
-[usage]: https://github.com/typicalninja/google-sr/blob/reformat-docs/packages/google-sr/src/results.ts
-
-<h1 align="center">Google-sr-selectors</h1>
+<h1 align="center">google-sr-selectors</h1>
 
 <p align="center">CSS Selectors for Google search page</p>
 
@@ -50,6 +41,23 @@ relying directly on google-sr-selectors.
 - [Discord][discord]
 
 
+# Notice for CommonJS users
+
+This package currently includes both [CommonJS (CJS)][cjs-nodejs-docs] and [ES Modules (ESM)][esm-nodejs-docs] builds.
+
+Starting with **v7.x** (subject to change), we plan to drop CJS support and publish only ESM-only builds.
+
+#### Why ESM-only going forward?
+- **Modern JavaScript**: ESM is now the standard, offering better support for tree-shaking and static analysis.
+- **Reduces package size**: Maintaining a single build reduces package size and build complexity.
+- [Node.js `v20`+ supports require() on ESM modules natively][nodejs-v20-backport-note] (no flags needed)
+
+While Node.js v20 already supports ESM well, we will wait until its End-of-Life before removing CJS to give users and tooling more time to transition.
+
+> Note: This applies only to Node.js users, other runtimes like Bun and Deno already support ESM natively
+
+See this [gist for future migration tips][esm-migration-pure-esm-gist] and our [GitHub discussion][cjs-build-notice-discussion] for more details.
+
 # Related projects 🥂
 
 * [google-sr][github-gsr] - Simple tool to programmatically get google search results
@@ -66,3 +74,19 @@ By using this project, you acknowledge that you are solely responsible for compl
 # License
 
 This repository and the code inside it is licensed under the Apache-2.0 License. Read [LICENSE](./LICENSE) for more information.
+
+
+[npm]: https://www.npmjs.com/package/google-sr-selectors
+[github-gsr]: https://github.com/typicalninja/google-sr/tree/master/packages/google-sr
+[github-gt]: https://github.com/typicalninja/google-sr/tree/master/packages/google-that
+[stargazers]: https://github.com/typicalninja/google-sr/stargazers
+[discord]: https://discord.gg/ynwckXS9T2
+[test-action]: https://github.com/typicalninja/google-sr/actions/workflows/tests.yml
+[api-docs]: https://typicalninja.github.io/google-sr/modules/google-sr-selectors_src.html
+[usage]: https://github.com/typicalninja/google-sr/blob/reformat-docs/packages/google-sr/src/results.ts
+
+[nodejs-v20-backport-note]:https://nodejs.org/en/blog/release/v20.19.0/
+[esm-nodejs-docs]: https://nodejs.org/api/esm.html#introduction
+[cjs-nodejs-docs]: https://nodejs.org/api/modules.html#modules-commonjs-modules
+[cjs-build-notice-discussion]: https://github.com/typicalninja/google-sr/discussions/86
+[esm-migration-pure-esm-gist]: https://gist.github.com/sindresorhus/a39789f98801d908bbc7ff3ecc99d99c

--- a/packages/google-sr-selectors/README.md
+++ b/packages/google-sr-selectors/README.md
@@ -75,6 +75,9 @@ By using this project, you acknowledge that you are solely responsible for compl
 
 This repository and the code inside it is licensed under the Apache-2.0 License. Read [LICENSE](./LICENSE) for more information.
 
+---
+
+Want to support the project? [Star it on GitHub ★][stargazers]
 
 [npm]: https://www.npmjs.com/package/google-sr-selectors
 [github-gsr]: https://github.com/typicalninja/google-sr/tree/master/packages/google-sr

--- a/packages/google-sr/README.md
+++ b/packages/google-sr/README.md
@@ -1,11 +1,3 @@
-[npm-gsr]: https://www.npmjs.com/package/google-sr
-[stargazers]: https://github.com/typicalninja/google-sr/stargazers
-[discord]: https://discord.gg/ynwckXS9T2
-[test-action]: https://github.com/typicalninja/google-sr/actions/workflows/tests.yml
-[api-docs]: https://typicalninja.github.io/google-sr/modules/google-sr_src.html
-[github-gt]: https://github.com/typicalninja/google-sr/tree/master/packages/google-that
-[github-gsrs]: https://github.com/typicalninja/google-sr/tree/master/packages/google-sr-selectors
-
 <h1 align="center">google-sr</h1>
 
 <p align="center">Scrape google search results without an API key with javascript/typescript.</p>
@@ -40,6 +32,8 @@
 # Install
 
 > Not supported in browser environments.
+
+> If you are using CommonJS, please read the [important notice](#notice-for-commonjs-users) about future ESM-only support.
 
 ```bash
 npm install google-sr
@@ -95,6 +89,23 @@ console.log(results); // see below
 - [NPM Package][npm-gsr]
 - [Discord][discord]
 
+# Notice for CommonJS users
+
+This package currently includes both [CommonJS (CJS)][cjs-nodejs-docs] and [ES Modules (ESM)][esm-nodejs-docs] builds.
+
+Starting with **v7.x** (subject to change), we plan to drop CJS support and publish only ESM-only builds.
+
+#### Why ESM-only going forward?
+- **Modern JavaScript**: ESM is now the standard, offering better support for tree-shaking and static analysis.
+- **Reduces package size**: Maintaining a single build reduces package size and build complexity.
+- [Node.js `v20`+ supports require() on ESM modules natively][nodejs-v20-backport-note] (no flags needed)
+
+While Node.js v20 already supports ESM well, we will wait until its End-of-Life before removing CJS to give users and tooling more time to transition.
+
+> Note: This applies only to Node.js users, other runtimes like Bun and Deno already support ESM natively
+
+See this [gist for future migration tips][esm-migration-pure-esm-gist] and our [GitHub discussion][cjs-build-notice-discussion] for more details.
+
 # Related projects 🥂
 
 - [google-that][github-gt] - CLI wrapper around google-sr
@@ -119,3 +130,18 @@ By using this project, you acknowledge that you are solely responsible for compl
 # License
 
 This repository and the code inside it is licensed under the Apache-2.0 License. Read [LICENSE](./LICENSE) for more information.
+
+
+[npm-gsr]: https://www.npmjs.com/package/google-sr
+[stargazers]: https://github.com/typicalninja/google-sr/stargazers
+[discord]: https://discord.gg/ynwckXS9T2
+[test-action]: https://github.com/typicalninja/google-sr/actions/workflows/tests.yml
+[api-docs]: https://typicalninja.github.io/google-sr/modules/google-sr_src.html
+[github-gt]: https://github.com/typicalninja/google-sr/tree/master/packages/google-that
+[github-gsrs]: https://github.com/typicalninja/google-sr/tree/master/packages/google-sr-selectors
+
+[nodejs-v20-backport-note]:https://nodejs.org/en/blog/release/v20.19.0/
+[esm-nodejs-docs]: https://nodejs.org/api/esm.html#introduction
+[cjs-nodejs-docs]: https://nodejs.org/api/modules.html#modules-commonjs-modules
+[cjs-build-notice-discussion]: https://github.com/typicalninja/google-sr/discussions/86
+[esm-migration-pure-esm-gist]: https://gist.github.com/sindresorhus/a39789f98801d908bbc7ff3ecc99d99c

--- a/packages/google-sr/README.md
+++ b/packages/google-sr/README.md
@@ -131,6 +131,9 @@ By using this project, you acknowledge that you are solely responsible for compl
 
 This repository and the code inside it is licensed under the Apache-2.0 License. Read [LICENSE](./LICENSE) for more information.
 
+---
+
+Want to support the project? [Star it on GitHub ★][stargazers]
 
 [npm-gsr]: https://www.npmjs.com/package/google-sr
 [stargazers]: https://github.com/typicalninja/google-sr/stargazers


### PR DESCRIPTION
This PR adds a section to the README to inform users that support for the CommonJS (CJS) build will be removed in a future major release (v7.x, subject to change). The package will transition to ES Modules (ESM)-only once Node.js v20 reaches End-of-Life (EOL).

Motivation
- Modern JavaScript ecosystems have standardized around ESM.
- Node.js v20+ [supports require() on ESM modules natively](https://nodejs.org/en/blog/release/v20.19.0/).
- Maintaining both CJS and ESM builds increases package size and build complexity.
- Popular runtimes like Bun and Deno already support ESM-only packages.

> If a breaking change requires a major version bump before that point, the CJS deprecation will be deferred to the following major version.

If you have any feedback regarding this, please see the associated discussion: #86 