### PR TITLE
chore: update cheerio to v1.1.0

### DIFF
--- a/packages/google-sr/package.json
+++ b/packages/google-sr/package.json
@@ -27,7 +27,7 @@
   "author": "typicalninja",
   "license": "Apache-2.0",
   "dependencies": {
-    "cheerio": "1.0.0-rc.12",
+    "cheerio": "1.1.0",
     "google-sr-selectors": "workspace:^"
   },
   "devDependencies": {

--- a/packages/google-sr/src/results/dictionary.ts
+++ b/packages/google-sr/src/results/dictionary.ts
@@ -1,4 +1,4 @@
-import type { Cheerio, Element } from "cheerio";
+import type { Cheerio } from "cheerio";
 // Importing the Selectors from google-sr-selectors
 import { DictionarySearchSelector, GeneralSelector } from "google-sr-selectors";
 import {
@@ -27,7 +27,8 @@ export interface DictionaryResultNode extends SearchResultNodeLike {
 
 // extract logic for parsing dictionary definitions into a separate function
 const parseDefinitionBlock = (
-	definitionBlock: Cheerio<Element>,
+	// biome-ignore lint/suspicious/noExplicitAny: Element type no longer exported from cheerio v1.1.0, avoiding domhandler dependency for single type usage
+	definitionBlock: Cheerio<any>,
 ): DictionaryDefinition | null => {
 	const definitionTextBlock = definitionBlock.find(
 		DictionarySearchSelector.definitionTextBlock,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -71,8 +71,8 @@ importers:
   packages/google-sr:
     dependencies:
       cheerio:
-        specifier: 1.0.0-rc.12
-        version: 1.0.0-rc.12
+        specifier: 1.1.0
+        version: 1.1.0
       google-sr-selectors:
         specifier: workspace:^
         version: link:../google-sr-selectors
@@ -886,10 +886,6 @@ packages:
   cheerio-select@2.1.0:
     resolution: {integrity: sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==}
 
-  cheerio@1.0.0-rc.12:
-    resolution: {integrity: sha512-VqR8m68vM46BNnuZ5NtnGBKIE/DfN0cRIzg9n40EIq9NOv90ayxLBXA8fXC5gquFRGJSTRqBq25Jt2ECLR431Q==}
-    engines: {node: '>= 6'}
-
   cheerio@1.1.0:
     resolution: {integrity: sha512-+0hMx9eYhJvWbgpKV9hN7jg0JcwydpopZE4hgi+KvQtByZXPp04NiCWU0LzcAbP63abZckIHkTQaXVF52mX3xQ==}
     engines: {node: '>=18.17'}
@@ -1204,9 +1200,6 @@ packages:
 
   htmlparser2@10.0.0:
     resolution: {integrity: sha512-TwAZM+zE5Tq3lrEHvOlvwgj1XLWQCtaaibSN11Q+gGBAS7Y1uZSWwXXRe4iF6OXnaq1riyQAPFOBtYc77Mxq0g==}
-
-  htmlparser2@8.0.2:
-    resolution: {integrity: sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==}
 
   human-id@4.1.1:
     resolution: {integrity: sha512-3gKm/gCSUipeLsRYZbbdA1BD83lBoWUkZ7G9VFrhWPAU76KwYo5KR8V28bpoPm/ygy0x5/GCbpRQdY7VLYCoIg==}
@@ -3001,16 +2994,6 @@ snapshots:
       domhandler: 5.0.3
       domutils: 3.2.2
 
-  cheerio@1.0.0-rc.12:
-    dependencies:
-      cheerio-select: 2.1.0
-      dom-serializer: 2.0.0
-      domhandler: 5.0.3
-      domutils: 3.2.2
-      htmlparser2: 8.0.2
-      parse5: 7.3.0
-      parse5-htmlparser2-tree-adapter: 7.1.0
-
   cheerio@1.1.0:
     dependencies:
       cheerio-select: 2.1.0
@@ -3348,13 +3331,6 @@ snapshots:
       domhandler: 5.0.3
       domutils: 3.2.2
       entities: 6.0.1
-
-  htmlparser2@8.0.2:
-    dependencies:
-      domelementtype: 2.3.0
-      domhandler: 5.0.3
-      domutils: 3.2.2
-      entities: 4.5.0
 
   human-id@4.1.1: {}
 


### PR DESCRIPTION
Version [1.x of cheerio had several breaking changes](https://github.com/cheeriojs/cheerio/releases/tag/v1.0.0) from the previous RC (release candidate) version, blocking us from updating.
This adapts the changes necessary and updates the cheerio dependency to [v1.1.0](https://github.com/cheeriojs/cheerio/releases/tag/v1.1.0)