### PR TITLE
refactor: make thumbnail_image in news results optional

### DIFF
--- a/packages/google-sr/src/results/news.ts
+++ b/packages/google-sr/src/results/news.ts
@@ -18,7 +18,7 @@ export interface NewsResultNode extends SearchResultNodeLike {
 	link: string;
 	source: string;
 	published_date: string;
-	thumbnail_image: string;
+	thumbnail_image?: string;
 }
 
 /**

--- a/packages/google-sr/tests/results.test.ts
+++ b/packages/google-sr/tests/results.test.ts
@@ -197,7 +197,6 @@ describe(
 				expect(res.title).to.be.a("string").and.not.empty;
 				expect(res.link).to.be.a("string").and.not.empty;
 				expect(res.source).to.be.a("string").and.not.empty;
-				expect(res.thumbnail_image).to.be.a("string").and.not.empty;
 			}
 		});
 	},


### PR DESCRIPTION
Some news results do not contain thumbnail images.