### PR TITLE
feat(google-sr): make OrganicResult description field optional

### DIFF
--- a/.changeset/tame-schools-kick.md
+++ b/.changeset/tame-schools-kick.md
@@ -1,0 +1,7 @@
+---
+"google-sr": major
+---
+
+Make OrganicResult description field optional
+
+The `description` field in `OrganicResultNode` is now optional (`string | undefined`) to handle cases where search results don't include a description. This is a breaking change as existing code may need to be updated to handle the undefined case.

--- a/packages/google-sr/src/results/organic.ts
+++ b/packages/google-sr/src/results/organic.ts
@@ -1,4 +1,3 @@
-// Importing the CSS Selectors from google-sr-selectors
 import { GeneralSelector, OrganicSearchSelector } from "google-sr-selectors";
 import {
 	type ResultParser,
@@ -15,7 +14,7 @@ import {
 export interface OrganicResultNode extends SearchResultNodeLike {
 	type: typeof ResultTypes.OrganicResult;
 	title: string;
-	description: string;
+	description?: string;
 	link: string;
 	source: string;
 	isAd: boolean;
@@ -46,7 +45,7 @@ export const OrganicResult: ResultParser<OrganicResultNode> = (
 	// Check if the user has called the function directly
 	// Most likely, they have passed the result of calling the function instead of the function itself
 	if (!$) throwNoCheerioError("OrganicResult");
-	//
+
 	const parsedResults: PartialExceptType<OrganicResultNode>[] = [];
 	const organicSearchBlocks = $(GeneralSelector.block).get();
 
@@ -64,11 +63,6 @@ export const OrganicResult: ResultParser<OrganicResultNode> = (
 		);
 		if (noPartialResults && !link) continue;
 
-		const description = coerceToStringOrUndefined(
-			$el.find(OrganicSearchSelector.description).text(),
-		);
-		if (noPartialResults && !description) continue;
-
 		const title = coerceToStringOrUndefined(
 			$el.find(OrganicSearchSelector.title).text(),
 		);
@@ -84,6 +78,11 @@ export const OrganicResult: ResultParser<OrganicResultNode> = (
 		// TODO: more data is required to figure out how this works
 		const metaAd = coerceToStringOrUndefined(
 			metaContainer.find(OrganicSearchSelector.metaAd).text(),
+		);
+
+		// Some result do not have the description
+		const description = coerceToStringOrUndefined(
+			$el.find(OrganicSearchSelector.description).text(),
 		);
 
 		parsedResults.push({

--- a/packages/google-sr/tests/results.test.ts
+++ b/packages/google-sr/tests/results.test.ts
@@ -58,8 +58,11 @@ describe(
 			for (const res of results) {
 				expect(res.type).toBe(ResultTypes.OrganicResult);
 				expect(res.link).to.be.a("string").and.not.empty;
-				expect(res.description).to.be.a("string").and.not.empty;
+				// description is optional, check if its a string or undefined
+				expect(["string", "undefined"]).toContain(typeof res.description);
+				expect(res.source).to.be.a("string").and.not.empty;
 				expect(res.title).to.be.a("string").and.not.empty;
+				expect(res.isAd).to.be.a("boolean");
 			}
 		});
 


### PR DESCRIPTION
## Breaking Change

Makes the `description` field in `OrganicResultNode` optional to handle cases where search results don't include a description.

### Changes
- Changed `description: string` to `description?: string | undefined` in `OrganicResultNode`