### PR TITLE
refactor(google-sr): use utf-8 to decode http response

### DIFF
--- a/apps/scraper/search-dump.ts
+++ b/apps/scraper/search-dump.ts
@@ -21,14 +21,13 @@ function formatBytes(bytes: number) {
 }
 
 const requestHeaders = {
-	Accept: "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+	Accept: "text/html, application/xhtml+xml, */*",
 	"Accept-Encoding": "gzip, deflate",
 	"Accept-Language": "en-US,en;q=0.5",
-	Connection: "keep-alive",
+	// IE 9 user agent to get no js google search page
+	"User-Agent": "Mozilla/5.0 (MSIE 10.0; Windows NT 6.1; Trident/5.0)",
+	Connection: "Keep-Alive",
 	Referer: "https://www.google.com/",
-	"Upgrade-Insecure-Requests": "1",
-	"User-Agent":
-		"Links (2.29; Linux 6.11.0-13-generic x86_64; GNU C 13.2; text)",
 };
 
 // Main function to handle the search dumping process
@@ -38,6 +37,7 @@ async function main(searchQuery: string) {
 	const searchParams = new URLSearchParams({
 		q: searchQuery,
 		hl: "en",
+		ie: "UTF-8",
 	});
 
 	const url = `https://www.google.com/search?${searchParams}`;
@@ -52,14 +52,17 @@ async function main(searchQuery: string) {
 		}
 
 		// Get data buffer and detect charset from headers
-		const dataBuffer = await response.arrayBuffer();
+		//const dataBuffer = await response.arrayBuffer();
 		const contentType = response.headers.get("content-type") || "";
 		const charsetMatch = contentType.match(/charset=([^;]+)/i);
 		const charset = charsetMatch ? charsetMatch[1].toLowerCase() : "iso-8859-1";
 
-		const data = new TextDecoder(charset).decode(dataBuffer);
+		// const data = new TextDecoder(charset).decode(dataBuffer);
+		const data = await response.text();
 		const dataBytes = formatBytes(data.length);
-		console.log(`📥 Received response: ${dataBytes}`);
+		console.log(
+			`📥 Received response: ${dataBytes} of ${charset} content type`,
+		);
 
 		const $ = cheerio.load(data);
 		const mainContent = $("html");

--- a/packages/google-sr-selectors/README.md
+++ b/packages/google-sr-selectors/README.md
@@ -24,12 +24,12 @@
 This package provides a set of CSS selectors for parsing Google search results, using tools such as [cheerio](https://github.com/cheeriojs/cheerio), etc...
 
 These selectors are compatible only with the search results page returned when the following user-agent is used:
-`Links (2.29; Linux 6.11.0-13-generic x86_64; GNU C 13.2; text)`.
+`Mozilla/5.0 (MSIE 10.0; Windows NT 6.1; Trident/5.0)`.
 
 #### Important Note:
-Due to the constantly evolving nature of Google's search page structure, we cannot guarantee consistent 
-usage/validity of these selectors. Unless you are an advanced user with specific requirements, **we highly recommend 
-using the [google-sr][github-gsr] package instead** of 
+Due to the constantly evolving nature of Google's search page structure, we cannot guarantee consistent
+usage/validity of these selectors. Unless you are an advanced user with specific requirements, **we highly recommend
+using the [google-sr][github-gsr] package instead** of
 relying directly on google-sr-selectors.
 
 

--- a/packages/google-sr/src/constants.ts
+++ b/packages/google-sr/src/constants.ts
@@ -121,4 +121,7 @@ export interface SearchOptionsWithPages<
 
 // source text is in the format "hello" in Japanese, we need to select the text between ""
 export const TranslateSourceTextRegex = /"(.+?)"/;
+// google will use their own link redirect path when you click on a result
+// instead of that we can use this to get the direct url
+export const GOOGLE_REDIRECT_URL_PARAM_REGEX = /[?&](q|imgurl|url)=([^&]+)/;
 export const GOOGLE_SEARCH_URL = "https://www.google.com/search";

--- a/packages/google-sr/src/search.ts
+++ b/packages/google-sr/src/search.ts
@@ -6,7 +6,6 @@ import type {
 } from "./constants.js";
 import { OrganicResult } from "./results/index.js";
 import {
-	decodeResponse,
 	prepareRequestConfig,
 	type SearchResultTypeFromParser,
 	safeGetFetch,
@@ -24,7 +23,7 @@ export async function search<R extends ResultParser, N extends boolean = false>(
 	const requestConfig = prepareRequestConfig(searchOptions);
 	const response = await safeGetFetch(requestConfig);
 	// we use the utility function to decode the data with the correct charset
-	const data = await decodeResponse(response);
+	const data = await response.text();
 	const cheerioApi = load(data);
 	// use the provided parsers or the default one (OrganicResult)
 	const parsers = searchOptions.parsers || [OrganicResult];
@@ -72,7 +71,7 @@ export async function searchWithPages<
 		);
 		const response = await safeGetFetch(baseRequestConfig);
 		// we use the utility function to decode the data with the correct charset
-		const data = await decodeResponse(response);
+		const data = await response.text();
 		const cheerioApi = load(data);
 		let pageResults: SearchResultTypeFromParser<R, N>[] = [];
 		for (const parser of parsers) {

--- a/packages/google-sr/src/utils.ts
+++ b/packages/google-sr/src/utils.ts
@@ -4,7 +4,10 @@ import type {
 	ResultTypes,
 	SearchOptions,
 } from "./constants.js";
-import { GOOGLE_SEARCH_URL } from "./constants.js";
+import {
+	GOOGLE_REDIRECT_URL_PARAM_REGEX,
+	GOOGLE_SEARCH_URL,
+} from "./constants.js";
 
 const baseHeaders = {
 	Accept: "text/html, application/xhtml+xml, */*",
@@ -50,11 +53,8 @@ export async function safeGetFetch(options: RequestOptions): Promise<Response> {
  */
 export function extractUrlFromGoogleLink(googleLink?: string): string | null {
 	if (!googleLink) return null;
-	// Regular expression to extract the `q` or `imgurl` parameter from the link
-	const regex = /[?&](q|imgurl)=([^&]+)/;
-
 	// Match the link against the regex
-	const match = googleLink.match(regex);
+	const match = googleLink.match(GOOGLE_REDIRECT_URL_PARAM_REGEX);
 	if (match?.[2]) {
 		try {
 			// Decode the extracted URL to handle encoded characters

--- a/packages/google-sr/src/utils.ts
+++ b/packages/google-sr/src/utils.ts
@@ -7,14 +7,13 @@ import type {
 import { GOOGLE_SEARCH_URL } from "./constants.js";
 
 const baseHeaders = {
-	Accept: "text/html",
+	Accept: "text/html, application/xhtml+xml, */*",
 	"Accept-Encoding": "gzip, deflate",
-	"Accept-Language": "en-US,en",
+	"Accept-Language": "en-US,en;q=0.5",
+	// Use a Internet Explorer < v10 user agent to avoid being required javaScript by google
+	"User-Agent": "Mozilla/5.0 (MSIE 10.0; Windows NT 6.1; Trident/5.0)",
+	Connection: "Keep-Alive",
 	Referer: "https://www.google.com/",
-	"upgrade-insecure-requests": "1",
-	// the tested user agent is for Chrome 103 on Windows 10
-	"User-Agent":
-		"Links (2.29; Linux 6.11.0-13-generic x86_64; GNU C 13.2; text)",
 };
 
 /**
@@ -41,21 +40,6 @@ export async function safeGetFetch(options: RequestOptions): Promise<Response> {
 	}
 
 	return response;
-}
-
-/**
- * @private
- * Try to decode the response body using the `ISO-8859-1` encoding,
- * @param response The response object from a fetch call
- * @returns The decoded response body as a string
- */
-export async function decodeResponse(response: Response): Promise<string> {
-	const dataBuffer = await response.arrayBuffer();
-
-	// During testing using the current user agent, the response was always in ISO-8859-1 encoding
-	// It is safe to assume that the response will always be in ISO-8859-1 encoding
-	// However if this were to change, then the text decoder will error
-	return new TextDecoder("iso-8859-1", { fatal: true }).decode(dataBuffer);
 }
 
 /**
@@ -115,6 +99,8 @@ export function prepareRequestConfig<R extends ResultParser, N extends boolean>(
 	// these params are always set without being overwritten
 	// set the actual query
 	requestConfig.queryParams.set("q", opts.query);
+	// set the input encoding to utf-8
+	requestConfig.queryParams.set("ie", "UTF-8");
 	requestConfig.url = GOOGLE_SEARCH_URL;
 
 	return requestConfig;

--- a/packages/google-sr/tests/utils.test.ts
+++ b/packages/google-sr/tests/utils.test.ts
@@ -1,24 +1,12 @@
 import { describe, expect, test, vi } from "vitest";
 import {
-	decodeResponse,
 	extractUrlFromGoogleLink,
 	prepareRequestConfig,
 	safeGetFetch,
 	throwNoCheerioError,
 } from "../src/utils.js";
 
-function createMockResponse(bytes: number[]): Response {
-	const buffer = new Uint8Array(bytes);
-	return new Response(buffer);
-}
-
 const nativeFetch = global.fetch;
-
-test("decodeResponse should decode latin1 encoding", async () => {
-	const mockedResponse = createMockResponse([0xa1, 0xa2]); // ¡, ¢
-	const decodedString = await decodeResponse(mockedResponse);
-	expect(decodedString).toBe("¡¢");
-});
 
 // Tests for extractUrlFromGoogleLink\
 describe("extractUrlFromGoogleLink", () => {
@@ -102,7 +90,7 @@ describe("prepareRequestConfig", () => {
 		});
 
 		expect(config.url).toBe("https://www.google.com/search");
-		expect(config.queryParams?.toString()).toBe("q=test");
+		expect(config.queryParams?.toString()).toBe("q=test&ie=UTF-8");
 		expect(config.headers).not.toBeUndefined();
 	});
 


### PR DESCRIPTION
In #75, when we replaced `axios` with native fetch we were getting `ISO-8859-1` encoded text for the user-agent we used. with further experimentation I was able to make google send `UTF-8` encoded text via an `IE 9` user-agent. additionally, the user-agent mentioned in the `google-sr-selectors` README was updated to the new one we use to prevent confusion.