### PR TITLE
fix: implement delay option in searchWithPages function

### DIFF
--- a/.changeset/busy-horses-float.md
+++ b/.changeset/busy-horses-float.md
@@ -1,0 +1,7 @@
+---
+"google-sr": patch
+---
+
+Fix delay option in searchWithPages function
+
+The delay option was previously defined in `SearchOptionsWithPages` interface but was not actually implemented in the `searchWithPages` function. This fix adds the missing delay functionality that applies the specified delay (default 1000ms) between page requests, helping to prevent rate limiting.

--- a/packages/google-sr/src/search.ts
+++ b/packages/google-sr/src/search.ts
@@ -115,6 +115,8 @@ export async function searchWithPages<
 		: Array.from({ length: options.pages }, (_, i) => i * 10);
 	const baseRequestConfig = prepareRequestConfig(options);
 	const parsers = options.parsers || [OrganicResult];
+	const delay = options.delay ?? 1000;
+
 	for (const page of pages) {
 		// params is guaranteed to be a URLSearchParams
 		// setting it here should be fine
@@ -137,6 +139,11 @@ export async function searchWithPages<
 		}
 
 		searchResults.push(pageResults);
+
+		// Add delay after processing each page (except the last one)
+		if (page !== pages[pages.length - 1] && delay > 0) {
+			await new Promise((resolve) => setTimeout(resolve, delay));
+		}
 	}
 
 	return searchResults;


### PR DESCRIPTION
Fixes the delay option in the `searchWithPages` function that was previously defined in the `SearchOptionsWithPages` interface but not actually implemented.